### PR TITLE
Adds LR decay scheduler.

### DIFF
--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -298,14 +298,11 @@ class BaseEncoderDecoder(pl.LightningModule):
             return []
         scheduler_fac = {
             "warmupinvsqrt": schedulers.WarmupInverseSquareRootSchedule,
-            "lineardecay": optim.lr_scheduler.LinearLR,
+            "lineardecay": schedulers.LinearDecay,
         }
         scheduler_cls = scheduler_fac[self.scheduler]
         scheduler = scheduler_cls(
-            **schedulers.filter_scheduler_kwargs(
-                scheduler_cls,
-                **dict(self.scheduler_kwargs, optimizer=optimizer)
-            ),
+            **dict(self.scheduler_kwargs, optimizer=optimizer)
         )
         scheduler_cfg = {
             "scheduler": scheduler,

--- a/yoyodyne/schedulers.py
+++ b/yoyodyne/schedulers.py
@@ -124,13 +124,17 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         "--start_factor",
         type=float,
         default=1 / 3,
-        help="The starting multiplier for the LR (lineardecay scheduler only). Default: %(default)s.",
+        help="The starting multiplier for the LR "
+        "(lineardecay scheduler only). "
+        "Default: %(default)s.",
     )
     parser.add_argument(
         "--end_factor",
         type=float,
         default=1.0,
-        help="The multiplier for the LR after total_decay_steps (lineardecay scheduler only). Default: %(default)s.",
+        help="The multiplier for the LR after total_decay_steps "
+        "(lineardecay scheduler only). "
+        "Default: %(default)s.",
     )
     parser.add_argument(
         "--total_decay_steps",

--- a/yoyodyne/schedulers.py
+++ b/yoyodyne/schedulers.py
@@ -34,6 +34,7 @@ class WarmupInverseSquareRootSchedule(optim.lr_scheduler.LambdaLR):
         optimizer: optim.Optimizer,
         warmup_steps,
         last_epoch=-1,
+        **kwargs,
     ):
         """Initializes the LR scheduler.
 
@@ -41,6 +42,7 @@ class WarmupInverseSquareRootSchedule(optim.lr_scheduler.LambdaLR):
             optimizer (optim.Optimizer): optimizer.
             warmup_steps (int): number of warmup steps.
             last_epoch (int): last epoch for the scheduler.
+            **kwargs: ignored.
         """
         self.warmup_steps = warmup_steps
         self.decay_factor = math.sqrt(warmup_steps)
@@ -62,6 +64,41 @@ class WarmupInverseSquareRootSchedule(optim.lr_scheduler.LambdaLR):
         if step < self.warmup_steps:
             return float(step) / float(max(1, self.warmup_steps))
         return self.decay_factor * step**-0.5
+
+
+class LinearDecay(optim.lr_scheduler.LinearLR):
+    """Linear decay scheduler."""
+
+    optimizer: optim.Optimizer
+    start_factor: float
+    end_factor: float
+    total_decay_steps: int
+    
+    def __init__(
+        self,
+        optimizer,
+        start_factor,
+        end_factor,
+        total_decay_steps,
+        **kwargs,
+    ):
+        """Initializes the LR scheduler.
+
+        Args:
+            optimizer (optim.Optimizer): optimizer.
+            start_factor (float): the start_factor to multiply by the LR.
+            end_factor (float): the end_factor to multiply by the LR 
+                after the total decay steps have finished.
+            total_decay_steps (int): number of steps to linearly update 
+                the multiplied factor until end_factor.
+            **kwargs: ignored.
+        """
+        super(LinearDecay, self).__init__(
+            optimizer,
+            total_iters=total_decay_steps,
+            start_factor=start_factor,
+            end_factor=end_factor,
+        )
 
 
 def add_argparse_args(parser: argparse.ArgumentParser) -> None:
@@ -88,40 +125,22 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         "--start_factor",
         type=float,
         default=1 / 3,
-        help="Start factor for lr decay. Default: %(default)s.",
+        help="The starting multiplier for the lr in LinearDecay. Default: %(default)s.",
     )
     parser.add_argument(
         "--end_factor",
         type=float,
         default=1.0,
-        help="End factor for lr decay. Default: %(default)s.",
+        help="The multiplier for the lr after total_decay_steps in LinearDecay. Default: %(default)s.",
     )
     parser.add_argument(
         "--total_decay_steps",
         type=int,
         default=5,
-        help="The number of iterations until linear decay factor "
-        "reaches end_factor. "
+        help="The number of iterations until the lr multiplier "
+        "reaches end_factor in LinearDecay. "
         "Default: %(default)s.",
     )
-
-
-def _map_scheduler_kwargs(k: str) -> Dict:
-    """Maps the scheduler kwargs from argparse into the names expected by
-    the actual scheduler.
-
-    This is to avoid issues between the yoyodyne namespace,
-    and the optim.lr_scheduler namespace.
-
-    Args:
-        k (str): name of the argparse argument
-
-    Returns:
-        Dict: scheduler kwargs in the optim.lr_scheduler namespace.
-    """
-    KWARGS_MAP = {"total_decay_steps": "total_iters"}
-
-    return KWARGS_MAP[k] if k in KWARGS_MAP else k
 
 
 def get_scheduler_kwargs_from_argparse_args(**kwargs) -> Dict:
@@ -130,21 +149,4 @@ def get_scheduler_kwargs_from_argparse_args(**kwargs) -> Dict:
     Returns:
         Dict: hyperparameters for the scheduler.
     """
-    return {_map_scheduler_kwargs(k): kwargs.get(k) for k in ALL_SCHEDULER_ARGS}
-
-
-def filter_scheduler_kwargs(scheduler_cls: optim.lr_scheduler, **kwargs) -> Dict:
-    """Filter all scheduler kwargs from argparse to only those
-    needed by the particular scheduler.
-
-    Args:
-        scheduler_cls (optim.lr_scheduler): class of the requested scheduler.
-
-    Returns:
-        Dict: kwargs for the requested scheduler.
-    """
-    valid_kwargs = [
-        p for p in inspect.signature(scheduler_cls.__init__).parameters if p != "self"
-    ]
-    # Overrides scheduler defaults that are provided in **kwargs.
-    return {k: kwargs[k] for k in valid_kwargs if kwargs.get(k) is not None}
+    return {k: kwargs.get(k) for k in ALL_SCHEDULER_ARGS}

--- a/yoyodyne/schedulers.py
+++ b/yoyodyne/schedulers.py
@@ -3,7 +3,6 @@
 
 import argparse
 import math
-import inspect
 from typing import Dict
 
 from torch import optim

--- a/yoyodyne/schedulers.py
+++ b/yoyodyne/schedulers.py
@@ -1,8 +1,15 @@
 """Custom schedulers."""
 
+
+import argparse
 import math
+import inspect
+from typing import Dict
 
 from torch import optim
+
+
+ALL_SCHEDULER_ARGS = ["warmup_steps", "start_factor", "end_factor", "total_decay_steps"]
 
 
 class WarmupInverseSquareRootSchedule(optim.lr_scheduler.LambdaLR):
@@ -55,3 +62,89 @@ class WarmupInverseSquareRootSchedule(optim.lr_scheduler.LambdaLR):
         if step < self.warmup_steps:
             return float(step) / float(max(1, self.warmup_steps))
         return self.decay_factor * step**-0.5
+
+
+def add_argparse_args(parser: argparse.ArgumentParser) -> None:
+    """Adds shared configuration options to the argument parser.
+
+    These are only needed at training time.
+
+    Args:
+        parser (argparse.ArgumentParser).
+    """
+    parser.add_argument(
+        "--scheduler",
+        choices=["warmupinvsqrt", "lineardecay"],
+        help="Learning rate scheduler",
+    )
+    parser.add_argument(
+        "--warmup_steps",
+        type=int,
+        default=0,
+        help="Number of warmup steps (warmupinvsqrt scheduler only). "
+        "Default: %(default)s.",
+    )
+    parser.add_argument(
+        "--start_factor",
+        type=float,
+        default=1 / 3,
+        help="Start factor for lr decay. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "--end_factor",
+        type=float,
+        default=1.0,
+        help="End factor for lr decay. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "--total_decay_steps",
+        type=int,
+        default=5,
+        help="The number of iterations until linear decay factor "
+        "reaches end_factor. "
+        "Default: %(default)s.",
+    )
+
+
+def _map_scheduler_kwargs(k: str) -> Dict:
+    """Maps the scheduler kwargs from argparse into the names expected by
+    the actual scheduler.
+
+    This is to avoid issues between the yoyodyne namespace,
+    and the optim.lr_scheduler namespace.
+
+    Args:
+        k (str): name of the argparse argument
+
+    Returns:
+        Dict: scheduler kwargs in the optim.lr_scheduler namespace.
+    """
+    KWARGS_MAP = {"total_decay_steps": "total_iters"}
+
+    return KWARGS_MAP[k] if k in KWARGS_MAP else k
+
+
+def get_scheduler_kwargs_from_argparse_args(**kwargs) -> Dict:
+    """Get's the Dict of kwargs that will be used to instantiate the scheduler.
+
+    Returns:
+        Dict: hyperparameters for the scheduler.
+    """
+    return {_map_scheduler_kwargs(k): kwargs.get(k) for k in ALL_SCHEDULER_ARGS}
+
+
+def filter_scheduler_kwargs(scheduler_cls: optim.lr_scheduler, **kwargs) -> Dict:
+    """Filter all scheduler kwargs from argparse to only those
+    needed by the particular scheduler.
+
+    Args:
+        scheduler_cls (optim.lr_scheduler): class of the requested scheduler.
+
+    Returns:
+        Dict: kwargs for the requested scheduler.
+    """
+    valid_kwargs = [
+        p for p in inspect.signature(scheduler_cls.__init__).parameters if p != "self"
+    ]
+    # Overrides scheduler defaults that are provided in **kwargs.
+    return {k: kwargs[k] for k in valid_kwargs if kwargs.get(k) is not None}

--- a/yoyodyne/schedulers.py
+++ b/yoyodyne/schedulers.py
@@ -74,11 +74,6 @@ class WarmupInverseSquareRootSchedule(optim.lr_scheduler.LambdaLR):
 class LinearDecay(optim.lr_scheduler.LinearLR):
     """Linear decay scheduler."""
 
-    optimizer: optim.Optimizer
-    start_factor: float
-    end_factor: float
-    total_decay_steps: int
-
     def __init__(
         self,
         optimizer,
@@ -130,26 +125,26 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         "--start_factor",
         type=float,
         default=1 / 3,
-        help="The starting multiplier for the lr in LinearDecay. Default: %(default)s.",
+        help="The starting multiplier for the LR (lineardecay scheduler only). Default: %(default)s.",
     )
     parser.add_argument(
         "--end_factor",
         type=float,
         default=1.0,
-        help="The multiplier for the lr after total_decay_steps in LinearDecay. Default: %(default)s.",
+        help="The multiplier for the LR after total_decay_steps (lineardecay scheduler only). Default: %(default)s.",
     )
     parser.add_argument(
         "--total_decay_steps",
         type=int,
         default=5,
-        help="The number of iterations until the lr multiplier "
-        "reaches end_factor in LinearDecay. "
+        help="The number of iterations until the LR multiplier "
+        "reaches end_factor (lineardecay scheduler only). "
         "Default: %(default)s.",
     )
 
 
 def get_scheduler_kwargs_from_argparse_args(**kwargs) -> Dict:
-    """Get's the Dict of kwargs that will be used to instantiate the scheduler.
+    """Gets the Dict of kwargs that will be used to instantiate the scheduler.
 
     Returns:
         Dict: hyperparameters for the scheduler.

--- a/yoyodyne/schedulers.py
+++ b/yoyodyne/schedulers.py
@@ -9,7 +9,12 @@ from typing import Dict
 from torch import optim
 
 
-ALL_SCHEDULER_ARGS = ["warmup_steps", "start_factor", "end_factor", "total_decay_steps"]
+ALL_SCHEDULER_ARGS = [
+    "warmup_steps",
+    "start_factor",
+    "end_factor",
+    "total_decay_steps",
+]
 
 
 class WarmupInverseSquareRootSchedule(optim.lr_scheduler.LambdaLR):
@@ -73,7 +78,7 @@ class LinearDecay(optim.lr_scheduler.LinearLR):
     start_factor: float
     end_factor: float
     total_decay_steps: int
-    
+
     def __init__(
         self,
         optimizer,
@@ -87,9 +92,9 @@ class LinearDecay(optim.lr_scheduler.LinearLR):
         Args:
             optimizer (optim.Optimizer): optimizer.
             start_factor (float): the start_factor to multiply by the LR.
-            end_factor (float): the end_factor to multiply by the LR 
+            end_factor (float): the end_factor to multiply by the LR
                 after the total decay steps have finished.
-            total_decay_steps (int): number of steps to linearly update 
+            total_decay_steps (int): number of steps to linearly update
                 the multiplied factor until end_factor.
             **kwargs: ignored.
         """

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -8,7 +8,7 @@ import pytorch_lightning as pl
 from pytorch_lightning import callbacks, loggers
 from torch.utils import data
 
-from . import collators, dataconfig, datasets, models, util
+from . import collators, dataconfig, datasets, models, schedulers, util
 
 
 class Error(Exception):
@@ -223,8 +223,7 @@ def get_model(
     optimizer: str = "adam",
     sed_params: Optional[str] = None,
     scheduler: Optional[str] = None,
-    warmup_steps: int = 0,
-    **kwargs,  # Ignored.
+    **kwargs,
 ) -> models.BaseEncoderDecoder:
     """Creates the model.
 
@@ -250,8 +249,7 @@ def get_model(
         optimizer (str).
         sed_params (str, optional).
         scheduler (str, optional).
-        warmup_steps (int, optional).
-        **kwargs: ignored.
+        **kwargs
 
     Returns:
         models.BaseEncoderDecoder.
@@ -266,6 +264,9 @@ def get_model(
         )
         if arch in ["transducer"]
         else None
+    )
+    scheduler_kwargs = schedulers.get_scheduler_kwargs_from_argparse_args(
+        **kwargs
     )
     # Please pass all arguments by keyword and keep in lexicographic order.
     return model_cls(
@@ -292,10 +293,10 @@ def get_model(
         output_size=train_set.index.target_vocab_size,
         pad_idx=train_set.index.pad_idx,
         scheduler=scheduler,
+        scheduler_kwargs=scheduler_kwargs,
         start_idx=train_set.index.start_idx,
         train_set=train_set,
         vocab_size=train_set.index.source_vocab_size,
-        warmup_steps=warmup_steps,
     )
 
 
@@ -369,6 +370,8 @@ def main() -> None:
     dataconfig.DataConfig.add_argparse_args(parser)
     # Architecture arguments.
     models.add_argparse_args(parser)
+    # Scheduler-specific arguments
+    schedulers.add_argparse_args(parser)
     # Architecture-specific arguments.
     models.BaseEncoderDecoder.add_argparse_args(parser)
     models.LSTMEncoderDecoder.add_argparse_args(parser)

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -370,7 +370,7 @@ def main() -> None:
     dataconfig.DataConfig.add_argparse_args(parser)
     # Architecture arguments.
     models.add_argparse_args(parser)
-    # Scheduler-specific arguments
+    # Scheduler-specific arguments.
     schedulers.add_argparse_args(parser)
     # Architecture-specific arguments.
     models.BaseEncoderDecoder.add_argparse_args(parser)


### PR DESCRIPTION
- Adds schedulers.add_argparse_args
- Refactors _get_lr_scheduler


I added some other functions to schedulers, to support converting from yoyodyne argparse args, to the torch scheduler args. We may also want to consider exposing the interval and frequency of schedule updates to the CLI. In this way, the `total_decay_steps` for the decay scheduler could be total_decay_iters, and depend on whether you request that the scheduler potentially update every step or epoch.

Also -- when I run my local `black`, it seems to modify most files, so I reverted that and just used my flake8 config. Is there anywhere I can see the linting setup for this repo, and apply it to my local?

Addresses #28 28