### PR TITLE
Rename length flags

### DIFF
--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -32,7 +32,7 @@ class BaseEncoderDecoder(pl.LightningModule):
     label_smoothing: Optional[float]
     # Decoding arguments.
     beam_width: int
-    max_decode_length: int
+    max_target_length: int
     # Model arguments.
     decoder_layers: int
     embedding_size: int
@@ -60,7 +60,7 @@ class BaseEncoderDecoder(pl.LightningModule):
         dropout=0.2,
         label_smoothing=None,
         beam_width=1,
-        max_decode_length=128,
+        max_target_length=128,
         decoder_layers=1,
         embedding_size=128,
         encoder_layers=1,
@@ -82,7 +82,7 @@ class BaseEncoderDecoder(pl.LightningModule):
         self.dropout = dropout
         self.label_smoothing = label_smoothing
         self.beam_width = beam_width
-        self.max_decode_length = max_decode_length
+        self.max_target_length = max_target_length
         self.decoder_layers = decoder_layers
         self.embedding_size = embedding_size
         self.encoder_layers = encoder_layers
@@ -415,7 +415,7 @@ class BaseEncoderDecoder(pl.LightningModule):
         )
         # Decoding arguments.
         parser.add_argument(
-            "--max_decode_length",
+            "--max_target_length",
             type=int,
             default=128,
             help="Maximum decoder string length. Default: %(default)s.",

--- a/yoyodyne/models/lstm.py
+++ b/yoyodyne/models/lstm.py
@@ -228,7 +228,7 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
         )
         predictions = []
         num_steps = (
-            target.size(1) if target is not None else self.max_decode_length
+            target.size(1) if target is not None else self.max_target_length
         )
         # Tracks when each sequence has decoded an EOS.
         finished = torch.zeros(batch_size, device=self.device)
@@ -290,7 +290,7 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
         decoder_hiddens = self.init_hiddens(encoder_out.size(0))
         # log likelihood, last decoded idx, all likelihoods,  hiddens tensor.
         histories = [[0.0, [self.start_idx], [0.0], decoder_hiddens]]
-        for t in range(self.max_decode_length):
+        for t in range(self.max_target_length):
             # List that stores the heap of the top beam_width elements from all
             # beam_width x output_size possibilities
             likelihoods = []

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -169,7 +169,7 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
         )
         predictions = []
         num_steps = (
-            target.size(1) if target is not None else self.max_decode_length
+            target.size(1) if target is not None else self.max_target_length
         )
         # Tracks when each sequence has decoded an EOS.
         finished = torch.zeros(batch_size, device=self.device)
@@ -430,7 +430,7 @@ class PointerGeneratorLSTMEncoderDecoderFeatures(
         )
         predictions = []
         num_steps = (
-            target.size(1) if target is not None else self.max_decode_length
+            target.size(1) if target is not None else self.max_target_length
         )
         # Tracks when each sequence has decoded an EOS.
         finished = torch.zeros(batch_size, device=self.device)

--- a/yoyodyne/models/positional_encoding.py
+++ b/yoyodyne/models/positional_encoding.py
@@ -17,18 +17,18 @@ class PositionalEncoding(nn.Module):
 
     pad_idx: int
 
-    def __init__(self, d_model: int, pad_idx, max_sequence_length: int = 128):
+    def __init__(self, d_model: int, pad_idx, max_source_length: int = 128):
         """
         Args:
             d_model (int).
             pad_idx (int).
-            max_sequence_length (int).
+            max_source_length (int).
         """
         super(PositionalEncoding, self).__init__()
         self.pad_idx = pad_idx
-        positional_encoding = torch.zeros(max_sequence_length, d_model)
+        positional_encoding = torch.zeros(max_source_length, d_model)
         position = torch.arange(
-            0, max_sequence_length, dtype=torch.float
+            0, max_source_length, dtype=torch.float
         ).unsqueeze(1)
         scale_factor = -math.log(10000.0) / d_model
         div_term = torch.exp(

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -140,7 +140,7 @@ class TransducerNoFeatures(lstm.LSTMEncoderDecoder):
             ]
         # Start of decoding.
         last_hiddens = self.init_hiddens(batch_size)
-        for _ in range(self.max_decode_length):
+        for _ in range(self.max_target_length):
             # Checks if completed all sequences.
             not_complete = last_action != self.actions.end_idx
             if not any(not_complete):
@@ -393,7 +393,7 @@ class TransducerNoFeatures(lstm.LSTMEncoderDecoder):
             target,
             alignment,
             prediction,
-            max_action_seq_len=self.max_decode_length,
+            max_action_seq_len=self.max_target_length,
         )
         action_scores = self.remap_actions(raw_action_scores)
         optimal_value = min(action_scores.values())

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -15,7 +15,7 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
 
     # Model arguments.
     attention_heads: int
-    max_sequence_length: int
+    max_source_length: int
     # Constructed inside __init__.
     esq: float
     source_embeddings: nn.Embedding
@@ -30,20 +30,20 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
         self,
         *args,
         attention_heads=4,
-        max_sequence_length=128,
+        max_source_length=128,
         **kwargs,
     ):
         """Initializes the encoder-decoder with attention.
 
         Args:
             attention_heads (int).
-            max_sequence_length (int).
+            max_source_length (int).
             *args: passed to superclass.
             **kwargs: passed to superclass.
         """
         super().__init__(*args, **kwargs)
         self.attention_heads = attention_heads
-        self.max_sequence_length = max_sequence_length
+        self.max_source_length = max_source_length
         self.esq = math.sqrt(self.embedding_size)
         self.source_embeddings = self.init_embeddings(
             self.vocab_size, self.embedding_size, self.pad_idx
@@ -52,7 +52,7 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
             self.output_size, self.embedding_size, self.pad_idx
         )
         self.positional_encoding = positional_encoding.PositionalEncoding(
-            self.embedding_size, self.pad_idx, self.max_sequence_length
+            self.embedding_size, self.pad_idx, self.max_source_length
         )
         self.log_softmax = nn.LogSoftmax(dim=2)
         encoder_layer = nn.TransformerEncoderLayer(
@@ -201,7 +201,7 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
         ]
         # Tracking when each sequence has decoded an EOS.
         finished = torch.zeros(batch_size, device=self.device)
-        for _ in range(self.max_decode_length):
+        for _ in range(self.max_target_length):
             target_tensor = torch.stack(predictions, dim=1)
             # Uses a dummy mask of all ones.
             target_mask = torch.ones_like(target_tensor, dtype=torch.float)
@@ -287,7 +287,7 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
             "(transformer-backed architectures only. Default: %(default)s.",
         )
         parser.add_argument(
-            "--max_sequence_length",
+            "--max_source_length",
             type=int,
             default=128,
             help="Maximum sequence length. Default: %(default)s.",

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -210,8 +210,8 @@ def get_model(
     embedding_size: int = 128,
     encoder_layers: int = 1,
     hidden_size: int = 512,
-    max_decode_length: int = 128,
-    max_sequence_length: int = 128,
+    max_target_length: int = 128,
+    max_source_length: int = 128,
     # Training arguments.
     batch_size: int = 32,
     beta1: float = 0.9,
@@ -236,8 +236,8 @@ def get_model(
         embedding_size (int).
         encoder_layers (int).
         hidden_size (int).
-        max_decode_length (int).
-        max_sequence_length (int).
+        max_target_length (int).
+        max_source_length (int).
         batch_size (int).
         beta1 (float).
         beta2 (float).
@@ -287,8 +287,8 @@ def get_model(
         features_idx=getattr(train_set.index, "features_idx", -1),
         hidden_size=hidden_size,
         learning_rate=learning_rate,
-        max_decode_length=max_decode_length,
-        max_sequence_length=max_sequence_length,
+        max_target_length=max_target_length,
+        max_source_length=max_source_length,
         optimizer=optimizer,
         output_size=train_set.index.target_vocab_size,
         pad_idx=train_set.index.pad_idx,


### PR DESCRIPTION
* `--max_sequence_length` -> `--max_source_length`
* `--max_decode_length` -> `--max_target_length`

This addresses commentary in #40. However it leaves open other parts of the bug, namely that it does not add documentation nor raise exceptions when the max lengths are exceeded by training data.