### PR TITLE
Adds scheduler reprs

### DIFF
--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -284,11 +284,12 @@ class BaseEncoderDecoder(pl.LightningModule):
         """
         optimizer = self._get_optimizer()
         scheduler = self._get_lr_scheduler(optimizer[0])
-        util.log_info("Optimizer details:")
-        util.log_info(optimizer)
         if scheduler:
             util.log_info("Scheduler details:")
             util.log_info(scheduler)
+        else:
+            util.log_info("Optimizer details:")
+            util.log_info(optimizer)
         return optimizer, scheduler
 
     def _get_optimizer(self) -> optim.Optimizer:

--- a/yoyodyne/schedulers.py
+++ b/yoyodyne/schedulers.py
@@ -49,6 +49,12 @@ class WarmupInverseSquareRootSchedule(optim.lr_scheduler.LambdaLR):
         self.decay_factor = math.sqrt(warmup_steps)
         super().__init__(optimizer, self.lr_lambda)
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"{self.optimizer}, {self.warmup_steps})"
+        )
+
     def lr_lambda(self, step: int) -> float:
         """Computes the learning rate lambda at a given step.
 
@@ -92,6 +98,13 @@ class LinearDecay(optim.lr_scheduler.LinearLR):
             total_iters=total_decay_steps,
             start_factor=start_factor,
             end_factor=end_factor,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"{self.optimizer}, {self.start_factor}, "
+            f"{self.end_factor}, {self.total_decay_steps})"
         )
 
 


### PR DESCRIPTION
Also mildly reconfigures to make the printout more pleasant.

After (transformer with warmupinvsqrt):

<pre>Scheduler details:
[{&apos;scheduler&apos;: WarmupInverseSquareRootSchedule(Adam (
Parameter Group 0
    amsgrad: False
    betas: (0.9, 0.98)
    capturable: False
    differentiable: False
    eps: 1e-08
    foreach: None
    fused: False
    initial_lr: 0.001
    lr: 0.0
    maximize: False
    weight_decay: 0
), 4000), &apos;interval&apos;: &apos;step&apos;, &apos;frequency&apos;: 1}]
</pre>