### PR TITLE
Adds automated LR tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Yoyodyne 🪀
-==========
+# Yoyodyne 🪀
 
 [![PyPI
 version](https://badge.fury.io/py/yoyodyne.svg)](https://pypi.org/project/yoyodyne)
@@ -18,11 +17,10 @@ models are particularly well-suited for problems where the source-target
 alignments are roughly monotonic (e.g., `transducer`) and/or where source and
 target vocabularies have substantial overlap (e.g., `pointer_generator_lstm`).
 
-Philosophy
-----------
+## Philosophy
 
 Yoyodyne is inspired by [FairSeq](https://github.com/facebookresearch/fairseq)
-but differs on several key points of design:
+(Ott et al. 2019) but differs on several key points of design:
 
 -   It is for small-vocabulary sequence-to-sequence generation, and therefore
     includes no affordances for machine translation or language modeling.
@@ -38,8 +36,7 @@ but differs on several key points of design:
 -   It uses validation accuracy (not loss) for model selection and early
     stoppping.
 
-Install
--------
+## Install
 
 First install dependencies:
 
@@ -55,14 +52,12 @@ It can then be imported like a regular Python module:
 import yoyodyne
 ```
 
-Usage
------
+## Usage
 
 See [`yoyodyne-predict --help`](yoyodyne/predict.py) and
 [`yoyodyne-train --help`](yoyodyne/train.py).
 
-Data format
------------
+## Data format
 
 The default data format is a two-column TSV file in which the first column is
 the source string and the second the target string.
@@ -84,40 +79,36 @@ Alternatively, for the SIGMORPHON 2016 shared task data format:
 
 this format is specified by `--features-col 2 --features-sep , --target-col 3`.
 
-Model checkpointing
--------------------
+## Model checkpointing
 
-Checkpointing is largely handled by
+Checkpointing is handled by
 [Lightning](https://pytorch-lightning.readthedocs.io/en/stable/common/checkpointing_basic.html).
 The path for model information, including checkpoints, is specified by a
 combination of `--model_dir` and `--experiment`, such that we build the path
-`model_dir/experiment_name/version_n`, where each run of an experiment with the
-same model\_dir and experiment\_name is namespaced with a new version number.
-Within a version, we store everything needed to reload a model, namely the
-hyperparameters (`model_dir/experiment_name/version_n/hparams.yaml`), and a
-directory of checkpoints (`model_dir/experiment_name/version_n/checkpoints`).
+`model_dir/experiment/version_n`, where each run of an experiment with the
+same `model\_dir` and `experiment` is namespaced with a new version number.
+A version stores everything needed to reload the model, including the
+hyperparameters (`model_dir/experiment_name/version_n/hparams.yaml`) and the
+checkpoints directory (`model_dir/experiment_name/version_n/checkpoints`).
 
 By default, each run initializes a new model from scratch, unless the
 `--train_from` argument is specified. To continue training from a specific
 checkpoint, the **full path to the checkpoint** should be specified with for the
-`--train_from` argument. This creates a new version, but starts from the
-provided model checkpoint.
+`--train_from` argument. This creates a new version, but starts training from
+the provided model checkpoint.
 
 During training, we save the best `--save_top_k` checkpoints (by default, 1)
-ranked according to accuray on the `--dev` set. For example, `--save_top_k 5`
-will save the top 5 most accurate models, according to the evaluation during
-training.
+ranked according to accuracy on the `--dev` set. For example, `--save_top_k 5`
+will save the top 5 most accurate models.
 
-Reserved symbols
-----------------
+## Reserved symbols
 
 Yoyodyne reserves symbols of the form `<...>` for internal use.
 Feature-conditioned models also use `[...]` to avoid clashes between feature
 symbols and source and target symbols. Therefore, users should not provide any
 symbols of form `<...>` or `[...]`.
 
-Architectures
--------------
+## Architectures
 
 The user specifies the model using the `--arch` flag (and in some cases
 additional flags).
@@ -137,8 +128,8 @@ additional flags).
 -   `transducer`: This is a transducer with an LSTM backend. On model creation,
     expectation maximization is used to learn a sequence of edit operations, and
     imitation learning is used to train the model to implement the oracle
-    policy, with roll-in controlled by the `--oracle_factor` flag (default: `1`).
-    Since this model assumes monotonic alignment, it may be superior to
+    policy, with roll-in controlled by the `--oracle_factor` flag (default:
+    `1`). Since this model assumes monotonic alignment, it may be superior to
     attentive models when the alignment between input and output is roughly
     monotonic and when input and output vocabularies overlap significantly.
 -   `transformer`: This is a transformer encoder-decoder with positional
@@ -156,8 +147,7 @@ By default, the `attentive_lstm`, `lstm`, `pointer_generator_lstm`, and
 `transducer` models use an bidirectional encoder. One can disable this with the
 `--no_bidirectional` flag.
 
-Training options
-----------------
+## Training options
 
 A non-exhaustive list includes:
 
@@ -170,8 +160,8 @@ A non-exhaustive list includes:
 -   Optimizer:
     -   `--learning_rate` (default: `.001`)
     -   `--optimizer` (default: `"adam"`)
-    -   `--beta1` (default: `.9`): $\beta_1$ hyperparameter for the Adam optimizer
-        (`--optimizer adam`)
+    -   `--beta1` (default: `.9`): $\beta_1$ hyperparameter for the Adam
+        optimizer (`--optimizer adam`)
     -   `--beta2` (default: `.99`): $\beta_2$ hyperparameter for the Adam
         optimizer (`--optimizer adam`)
     -   `--scheduler` (default: not enabled)
@@ -193,8 +183,13 @@ biLSTM. For transformer-based architectures, experiment with multiple encoder
 and decoder layers, much larger batches, and the warmup-plus-inverse square root
 decay scheduler.
 
-Accelerators
-------------
+## Automatic tuning
+
+`yododyne-train --auto_lr_find` uses a heuristic (see [Smith
+2017](https://ieeexplore.ieee.org/abstract/document/7926641)) to propose an
+initial learning rate. Batch auto-scaling is not supported.
+
+## Accelerators
 
 [Hardware
 accelerators](https://pytorch-lightning.readthedocs.io/en/stable/extensions/accelerator.html)
@@ -203,12 +198,23 @@ GPU (`--accelerator gpu`), [other
 accelerators](https://pytorch-lightning.readthedocs.io/en/stable/extensions/accelerator.html)
 may also be supported but not all have been tested yet.
 
-Precision
----------
+## Precision
 
 By default, training uses 32-bit precision. However, the `--precision` flag
-allows the user to perfrom training with half precision (`16`) or with the
+allows the user to perform training with half precision (`16`) or with the
 [`bfloat16` half precision
-format](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format), where
+format](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format) if
 supported by the accelerator. This may reduce the size of the model and batches
 in memory, allowing one to use larger batches.
+
+## References
+
+Ott, M., Edunov, S., Baevski, A., Fan, A., Gross, S., Ng, N., Grangier, D., and
+Auli, M. 2019. [fairseq: a fast, extensible toolkit for sequence
+modeling](https://aclanthology.org/N19-4009/). In *Proceedings of the 2019
+Conference of the North American Chapter of the Association for Computational
+Linguistics (Demonstrations)*, pages 48-53.
+
+Smith, L. N. 2017. [Cyclical learning rates for training neural
+networks](https://ieeexplore.ieee.org/abstract/document/7926641). In *2017 IEEE
+Winter Conference on Applications of Computer Vision*, pages 464-472.

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -395,6 +395,7 @@ def main() -> None:
     models.expert.add_argparse_args(parser)
     # Trainer arguments.
     # Among the things this adds, the following are likely to be useful:
+    # --auto_lr_find
     # --accelerator ("gpu" for GPU)
     # --check_val_every_n_epoch
     # --devices (for multiple device support)
@@ -450,6 +451,12 @@ def main() -> None:
         args.max_target_length,
     )
     model = get_model(train_set, **vars(args))
+    # If requested, tune the LR, and log the suggested value, and exit.
+    if args.auto_lr_find:
+        result = trainer.tuner.lr_find(model, train_loader, dev_loader)
+        util.log_info(f"Best initial LR: {result.suggestion():.8f}")
+        return
+    # Otherwise, train and log the best checkpoint.
     best_checkpoint = train(
         trainer, model, train_loader, dev_loader, args.train_from
     )

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -451,7 +451,11 @@ def main() -> None:
         args.max_target_length,
     )
     model = get_model(train_set, **vars(args))
-    # If requested, tune the LR, and log the suggested value, and exit.
+    # Tuning options. Batch autoscaling is unsupported; LR tuning logs the
+    # suggested value and then exits.
+    if args.auto_scale_batch_size:
+        raise Error("Batch auto-scaling is not supported")
+        return
     if args.auto_lr_find:
         result = trainer.tuner.lr_find(model, train_loader, dev_loader)
         util.log_info(f"Best initial LR: {result.suggestion():.8f}")


### PR DESCRIPTION
The PTL trainer supports two kinds of auto-tuning as an alternative to actual training: one for batch size (which just tries to find the biggest value) and one for LR (which is a bit more sophisticated). Here, I have made the --auto_lr_find flag work.

If this flag is invoked, we run the tuner instead of the trainer's fit method, log the result, and then quit. Otherwise, training proceeds as normal.

I did not bother to enable the batch size one as it is substantially more work.

Only question is: do we want this?