### PR TITLE
Fix lstm encoder layers

### DIFF
--- a/yoyodyne/models/lstm.py
+++ b/yoyodyne/models/lstm.py
@@ -288,7 +288,9 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
                 "Beam search is not implemented for batch_size > 1"
             )
         # Initializes hidden states for decoder LSTM.
-        decoder_hiddens = self.init_hiddens(encoder_out.size(0), self.decoder_layers)
+        decoder_hiddens = self.init_hiddens(
+            encoder_out.size(0), self.decoder_layers
+        )
         # log likelihood, last decoded idx, all likelihoods,  hiddens tensor.
         histories = [[0.0, [self.start_idx], [0.0], decoder_hiddens]]
         for t in range(self.max_target_length):

--- a/yoyodyne/models/lstm.py
+++ b/yoyodyne/models/lstm.py
@@ -174,7 +174,7 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
         return output, hiddens
 
     def init_hiddens(
-        self, batch_size: int
+        self, batch_size: int, num_layers: int
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Initializes the hidden state to pass to the LSTM.
 
@@ -182,14 +182,15 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
 
         Args:
             batch_size (int).
+            num_layers (int).
 
         Returns:
             Tuple[torch.Tensor, torch.Tensor]: hidden cells for LSTM
                 initialization.
         """
         return (
-            self.h0.repeat(self.encoder_layers, batch_size, 1),
-            self.c0.repeat(self.encoder_layers, batch_size, 1),
+            self.h0.repeat(num_layers, batch_size, 1),
+            self.c0.repeat(num_layers, batch_size, 1),
         )
 
     def decode(
@@ -216,7 +217,7 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
                 seq_len x batch_size x output_size.
         """
         # Initializes hidden states for decoder LSTM.
-        decoder_hiddens = self.init_hiddens(batch_size)
+        decoder_hiddens = self.init_hiddens(batch_size, self.decoder_layers)
         # Feed in the first decoder input, as a start tag.
         # -> B x 1.
         decoder_input = (
@@ -287,7 +288,7 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
                 "Beam search is not implemented for batch_size > 1"
             )
         # Initializes hidden states for decoder LSTM.
-        decoder_hiddens = self.init_hiddens(encoder_out.size(0))
+        decoder_hiddens = self.init_hiddens(encoder_out.size(0), self.decoder_layers)
         # log likelihood, last decoded idx, all likelihoods,  hiddens tensor.
         histories = [[0.0, [self.start_idx], [0.0], decoder_hiddens]]
         for t in range(self.max_target_length):

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -365,10 +365,12 @@ class PointerGeneratorLSTMEncoderDecoderFeatures(
         )
         # -> B x 1 x 4*hidden_size.
         context = torch.cat([source_context, feature_context], dim=2)
+        # num_layers x B x hidden_size
         _, (h, c) = self.decoder(
             torch.cat((embedded, context), 2), (last_h, last_c)
         )
-        hidden = h.transpose(0, 1)
+        # -> B x 1 x hidden_size
+        hidden = h[-1, :, :].unsqueeze(1)
         output_probs = self.classifier(torch.cat([hidden, context], dim=2))
         # Ordinary softmax, log will be taken at the end.
         output_probs = nn.functional.softmax(output_probs, dim=2)

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -9,7 +9,7 @@ from .. import batches
 from . import attention, generation_probability, lstm
 
 
-class PointerGeneratorError(Exception):
+class Error(Exception):
     pass
 
 
@@ -48,12 +48,12 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
         """Checks that encoder and decoder layers are the same number.
 
         Raises:
-            PointerGeneratorError: _description_
+            Error.
         """
         if self.encoder_layers != self.decoder_layers:
             msg = "encoder_layers needs to be the same as decoder_layers."
             msg += f" {self.encoder_layers} != {self.decoder_layers}."
-            raise PointerGeneratorError(msg)
+            raise Error(msg)
 
     def encode(
         self,

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -54,7 +54,7 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
             msg = f"encoder_layers needs to be the same as decoder_layers."
             msg += f" {self.encoder_layers} != {self.decoder_layers}."
             raise PointerGeneratorError(msg)
-        
+
     def encode(
         self,
         source: batches.PaddedTensor,

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -51,7 +51,7 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
             PointerGeneratorError: _description_
         """
         if self.encoder_layers != self.decoder_layers:
-            msg = f"encoder_layers needs to be the same as decoder_layers."
+            msg = "encoder_layers needs to be the same as decoder_layers."
             msg += f" {self.encoder_layers} != {self.decoder_layers}."
             raise PointerGeneratorError(msg)
 

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -109,7 +109,8 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
         _, (h, c) = self.decoder(
             torch.cat((embedded, source_context), 2), (last_h, last_c)
         )
-        hidden = h.transpose(0, 1)
+        # -> B x 1 x hidden_size
+        hidden = h[-1, :, :].unsqueeze(1)
         output_probs = self.classifier(
             torch.cat([hidden, source_context], dim=2)
         )

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -139,7 +139,7 @@ class TransducerNoFeatures(lstm.LSTMEncoderDecoder):
                 for t, tmask in zip(target, target_mask)
             ]
         # Start of decoding.
-        last_hiddens = self.init_hiddens(batch_size)
+        last_hiddens = self.init_hiddens(batch_size, self.decoder_layers)
         for _ in range(self.max_target_length):
             # Checks if completed all sequences.
             not_complete = last_action != self.actions.end_idx


### PR DESCRIPTION
LSTM variants and pointer generator now works for >1 layers. There was a bug in the `init_hiddens` that used the number of encoder layers, not decoder. We also need to, for pointer generator, request only the last layer to use with the feature attentions.

However, the pointer generator now breaks when `encoder_layers != decoder_layers` because we follow the paper in initializing the decoder with the last encoder state. I *could* probably get the `n` last layers where `n` is `decoder_layers`, but this seems weird and also means that we still have the constraint that `encoder_layers >= decoder_layers`.

I think we either need to assert that `encoder_layers != decoder_layers`, or diverge from the paper and initialize the decoder like how we do the other LSTM models. I don't expect the latter to have much negative impact, but of course we'd want to test and compare results on some languages.