### PR TITLE
Fixed batch sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ A non-exhaustive list includes:
 
 -   Batch size:
     -   `--batch_size` (default: `32`)
+    -   `--pad_max` (default: not enabled): gives a consistent batch size
 -   Regularization:
     -   `--dropout` (default: `.2`)
     -   `--label_smoothing` (default: not enabled)

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ Checkpointing is handled by
 [Lightning](https://pytorch-lightning.readthedocs.io/en/stable/common/checkpointing_basic.html).
 The path for model information, including checkpoints, is specified by a
 combination of `--model_dir` and `--experiment`, such that we build the path
-`model_dir/experiment/version_n`, where each run of an experiment with the
-same `model_dir` and `experiment` is namespaced with a new version number.
-A version stores everything needed to reload the model, including the
-hyperparameters (`model_dir/experiment_name/version_n/hparams.yaml`) and the
-checkpoints directory (`model_dir/experiment_name/version_n/checkpoints`).
+`model_dir/experiment/version_n`, where each run of an experiment with the same
+`model_dir` and `experiment` is namespaced with a new version number. A version
+stores everything needed to reload the model, including the hyperparameters
+(`model_dir/experiment_name/version_n/hparams.yaml`) and the checkpoints
+directory (`model_dir/experiment_name/version_n/checkpoints`).
 
 By default, each run initializes a new model from scratch, unless the
 `--train_from` argument is specified. To continue training from a specific
@@ -151,14 +151,11 @@ By default, the `attentive_lstm`, `lstm`, `pointer_generator_lstm`, and
 
 A non-exhaustive list includes:
 
--   Batch size:
-    -   `--batch_size` (default: `32`)
-    -   `--pad_max` (default: not enabled): gives a consistent batch size
 -   Regularization:
     -   `--dropout` (default: `.2`)
     -   `--label_smoothing` (default: not enabled)
     -   `--gradient_clip_val` (default: not enabled)
--   Optimizer:
+-   Optimization:
     -   `--learning_rate` (default: `.001`)
     -   `--optimizer` (default: `"adam"`)
     -   `--beta1` (default: `.9`): $\beta_1$ hyperparameter for the Adam
@@ -166,17 +163,21 @@ A non-exhaustive list includes:
     -   `--beta2` (default: `.99`): $\beta_2$ hyperparameter for the Adam
         optimizer (`--optimizer adam`)
     -   `--scheduler` (default: not enabled)
--   Duration:
+-   Training duration:
     -   `--max_epochs`
     -   `--min_epochs`
     -   `--max_steps`
     -   `--min_steps`
     -   `--max_time`
     -   `--patience`
--   Seeding:
+-   Sequence length:
+    -   `--max_source_length` (default: `128`)
+    -   `--max_target_length` (default: `128`)
+-   Other:
+    -   `--batch_size` (default: `32`)
     -   `--seed`
--   [Weights & Biases](https://wandb.ai/site):
-    -   `--wandb` (default: `False`): enables Weights & Biases tracking
+    -   `--wandb` (default: `False`): enables [Weights &
+        Biases](https://wandb.ai/site) tracking
 
 **No neural model should be deployed without proper hyperparameter tuning.**
 However, the default options give a reasonable initial settings for an attentive

--- a/yoyodyne/collators.py
+++ b/yoyodyne/collators.py
@@ -82,7 +82,7 @@ class Collator:
         Args:
             padded_length (int): The length of the the padded tensor.
         """
-        if self.max_target_length and padded_length > self.max_target_length:
+        if padded_length > self.max_target_length:
             msg = f"The length of a batch ({padded_length}) "
             msg += "is greater than the `--max_target_length` specified "
             msg += f"({self.max_target_length}). This means that "

--- a/yoyodyne/collators.py
+++ b/yoyodyne/collators.py
@@ -29,8 +29,7 @@ class Collator:
         arch: str,
         max_source_length=defaults.MAX_SOURCE_LENGTH,
         max_target_length=defaults.MAX_TARGET_LENGTH,
-        # FIXME: Handle length.
-        # max_features_length=defaults.MAX_FEATURES_LENGTH,
+        # FIXME: max features length.
     ):
         """Initializes the collator.
 
@@ -53,8 +52,7 @@ class Collator:
         ]
         self.max_source_length = max_source_length
         self.max_target_length = max_target_length
-        # FIXME: Handle length.
-        # self.max_features_length = max_features_length
+        # FIXME: max features length.
 
     def _source_length_error(self, padded_length: int):
         """Callback function to raise the error when the padded length of the
@@ -137,8 +135,8 @@ class Collator:
         return batches.PaddedTensor(
             self.concatenate_source_and_features(itemlist),
             self.pad_idx,
-            # FIXME: Handle length.
             self.max_source_length,
+            # FIXME: max features length.
             self._source_length_error,
         )
 
@@ -157,7 +155,7 @@ class Collator:
         return batches.PaddedTensor(
             [item.features for item in itemlist],
             self.pad_idx,
-            # FIXME: Handle length.
+            # FIXME: max features length.
         )
 
     def pad_target(
@@ -218,10 +216,4 @@ class Collator:
             default=defaults.MAX_TARGET_LENGTH,
             help="Maximum target string length. Default: %(default)s.",
         )
-        # FIXME: Handle length.
-        # parser.add_argument(
-        #    "--max_features_length",
-        #    type=int,
-        #    default=defaults.MAX_FEATURES_LENGTH,
-        #    help="Maximum features string length. Default: %(default)s.",
-        # )
+        # FIXME: max features length.

--- a/yoyodyne/datasets.py
+++ b/yoyodyne/datasets.py
@@ -117,12 +117,12 @@ class DatasetNoFeatures(BaseDataset):
     @functools.cached_property
     def max_source_length(self) -> int:
         # " + 2" for start and end tag.
-        return max(len(source) + 2 for source, _, *_ in self.samples)
+        return max(len(source) for source, _, *_ in self.samples) + 2
 
     @functools.cached_property
     def max_target_length(self) -> int:
         # " + 1" for end tag.
-        return max(len(target) + 1 for _, target, *_ in self.samples)
+        return max(len(target) for _, target, *_ in self.samples) + 1
 
     def encode(
         self,

--- a/yoyodyne/datasets.py
+++ b/yoyodyne/datasets.py
@@ -45,18 +45,6 @@ class Item(nn.Module):
     def has_target(self):
         return self.target is not None
 
-    @property
-    def source_len(self) -> int:
-        return len(self.source)
-
-    @property
-    def target_len(self) -> int:
-        return len(self.target) if self.target else 0
-
-    @property
-    def features_len(self) -> int:
-        return len(self.features) if self.features else 0
-
 
 class BaseDataset(data.Dataset):
     """Base datatset class, with some core methods."""

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -32,6 +32,7 @@ class BaseEncoderDecoder(pl.LightningModule):
     label_smoothing: Optional[float]
     # Decoding arguments.
     beam_width: int
+    max_source_length: int
     max_target_length: int
     # Model arguments.
     decoder_layers: int
@@ -60,6 +61,7 @@ class BaseEncoderDecoder(pl.LightningModule):
         dropout=defaults.DROPOUT,
         label_smoothing=None,
         beam_width=defaults.BEAM_WIDTH,
+        max_source_length=defaults.MAX_SOURCE_LENGTH,
         max_target_length=defaults.MAX_TARGET_LENGTH,
         decoder_layers=defaults.DECODER_LAYERS,
         embedding_size=defaults.EMBEDDING_SIZE,
@@ -82,6 +84,7 @@ class BaseEncoderDecoder(pl.LightningModule):
         self.dropout = dropout
         self.label_smoothing = label_smoothing
         self.beam_width = beam_width
+        self.max_source_length = max_source_length
         self.max_target_length = max_target_length
         self.decoder_layers = decoder_layers
         self.embedding_size = embedding_size

--- a/yoyodyne/models/lstm.py
+++ b/yoyodyne/models/lstm.py
@@ -118,7 +118,7 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
             packed_outs,
             batch_first=True,
             padding_value=self.pad_idx,
-            total_length=None,
+            total_length=self.max_source_length,
         )
         return encoded, (H, C)
 

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -336,7 +336,7 @@ class PointerGeneratorLSTMEncoderDecoderFeatures(
             packed_outs,
             batch_first=True,
             padding_value=self.pad_idx,
-            total_length=None,
+            total_length=self.max_source_length,
         )
         # Sums over directions, keeping layers.
         # -> num_layers x B x hidden_size.

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -81,7 +81,7 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
             packed_outs,
             batch_first=True,
             padding_value=self.pad_idx,
-            total_length=None,
+            total_length=self.max_source_length,
         )
         # Sums over directions, keeping layers.
         # -> num_layers x B x hidden_size.

--- a/yoyodyne/models/positional_encoding.py
+++ b/yoyodyne/models/positional_encoding.py
@@ -6,8 +6,6 @@ from typing import Optional
 import torch
 from torch import nn
 
-from .. import defaults
-
 
 class PositionalEncoding(nn.Module):
     """Positional encoding.
@@ -17,25 +15,24 @@ class PositionalEncoding(nn.Module):
     """
 
     pad_idx: int
+    positional_encoding: torch.Tensor
 
     def __init__(
         self,
         d_model: int,
         pad_idx,
-        max_source_length: int = defaults.MAX_SOURCE_LENGTH,
+        max_length,
     ):
         """
         Args:
             d_model (int).
             pad_idx (int).
-            max_source_length (int).
+            max_length (int).
         """
-        super(PositionalEncoding, self).__init__()
+        super().__init__()
         self.pad_idx = pad_idx
-        positional_encoding = torch.zeros(max_source_length, d_model)
-        position = torch.arange(
-            0, max_source_length, dtype=torch.float
-        ).unsqueeze(1)
+        positional_encoding = torch.zeros(max_length, d_model)
+        position = torch.arange(max_length, dtype=torch.float).unsqueeze(1)
         scale_factor = -math.log(10000.0) / d_model
         div_term = torch.exp(
             torch.arange(0, d_model, 2).float() * scale_factor

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -454,18 +454,15 @@ def main() -> None:
     index = _get_index_from_argparse_args(args)
     train_set.index.write(index)
     util.log_info(f"Index: {index}")
-    # Truncates max lengths based on the actual data.
-    # FIXME: hackish.
+    # Truncates max lengths based on the actual lengths.
     args.max_source_length = min(
         args.max_source_length,
         max(train_set.max_source_length, dev_set.max_source_length),
     )
-    util.log_info(f"True maximum source length: {args.max_source_length}")
     args.max_target_length = min(
         args.max_target_length,
         max(train_set.max_target_length, dev_set.max_target_length),
     )
-    util.log_info(f"True maximum target length: {args.max_target_length}")
     train_loader, dev_loader = get_loaders(
         train_set,
         dev_set,
@@ -473,6 +470,7 @@ def main() -> None:
         args.batch_size,
         args.max_source_length,
         args.max_target_length,
+        # FIXME: max features length.
     )
     model = get_model(train_set, **vars(args))
     # Tuning options. Batch autoscaling is unsupported; LR tuning logs the

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -455,15 +455,17 @@ def main() -> None:
     train_set.index.write(index)
     util.log_info(f"Index: {index}")
     # Truncates max lengths based on the actual data.
-    # FIXME can I generalize this?
+    # FIXME: hackish.
     args.max_source_length = min(
         args.max_source_length,
         max(train_set.max_source_length, dev_set.max_source_length),
     )
+    util.log_info(f"True maximum source length: {args.max_source_length}")
     args.max_target_length = min(
         args.max_target_length,
         max(train_set.max_target_length, dev_set.max_target_length),
     )
+    util.log_info(f"True maximum target length: {args.max_target_length}")
     train_loader, dev_loader = get_loaders(
         train_set,
         dev_set,

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -414,6 +414,12 @@ def main() -> None:
         help="Batch size. Default: %(default)s.",
     )
     parser.add_argument(
+        "--pad_max",
+        action="store_true",
+        help="Pads all batches to the same length. Default: False.",
+    )
+    parser.add_argument("--no_pad_max", action="store_false", dest="pad_max")
+    parser.add_argument(
         "--patience", type=int, help="Patience for early stopping"
     )
     parser.add_argument(


### PR DESCRIPTION
This is a draft. Important simplifications while I get the basics right:

* I assume that we are always padding to the max (for source and target); I can make it optional later, though the performance penalty is quite small in my experiments.
* I am ignoring feature models for now; that can be incorporated later.
* Prediction isn't tested yet.

I set the actual source_max_length to the min(max(longest source string in train, longest source string in dev), --max_source_length)), and similarly for target length. I then lightly modify the LSTM (it needs to be told the max source length) and the transformer (it needs to make the positional embedding as large as max of the longest source and target string). Everything else is just plumbing.

Closes #50.