### PR TITLE
Fixes decoding twice in validation

### DIFF
--- a/yoyodyne/defaults.py
+++ b/yoyodyne/defaults.py
@@ -33,6 +33,7 @@ ORACLE_FACTOR = 1
 OPTIMIZER = "adam"
 SAVE_TOP_K = 1
 WANDB = False
+TEACHER_FORCING = True
 
 # Decoding arguments.
 BEAM_WIDTH = 1

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -435,11 +435,6 @@ class BaseEncoderDecoder(pl.LightningModule):
             type=float,
             help="Coefficient for label smoothing.",
         )
-        parser.add_argument(
-            "--teacher_forcing",
-            default=defaults.TEACHER_FORCING,
-            help="Use teacher forcing while training. Default: %(default)s.",
-        )
         # TODO: add --beam_width.
         # Model arguments.
         parser.add_argument(

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -217,7 +217,9 @@ class BaseEncoderDecoder(pl.LightningModule):
         # -> B x output_size x seq_len. For loss.
         greedy_predictions = greedy_predictions.transpose(1, 2)
         # Truncates predictions to the size of the target.
-        greedy_predictions = torch.narrow(greedy_predictions, 2, 0, target_padded.size(1))
+        greedy_predictions = torch.narrow(
+            greedy_predictions, 2, 0, target_padded.size(1)
+        )
         loss = self.loss_func(greedy_predictions, target_padded)
         return {"val_accuracy": accuracy, "val_loss": loss}
 

--- a/yoyodyne/models/lstm.py
+++ b/yoyodyne/models/lstm.py
@@ -247,6 +247,9 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
             # In teacher forcing mode the next input is the gold symbol
             # for this step.
             if teacher_forcing:
+                assert (
+                    target is not None
+                ), "Teacher forcing requested but no target provided"
                 decoder_input = target[:, t].unsqueeze(1)
             # Otherwise we pass the top pred to the next timestep
             # (i.e., student forcing, greedy decoding).

--- a/yoyodyne/models/lstm.py
+++ b/yoyodyne/models/lstm.py
@@ -199,7 +199,7 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
         encoder_mask: torch.Tensor,
         encoder_out: torch.Tensor,
         target: Optional[torch.Tensor] = None,
-        teacher_forcing: Optional[bool] = True
+        teacher_forcing: Optional[bool] = True,
     ) -> torch.Tensor:
         """Decodes a sequence given the encoded input.
 
@@ -245,7 +245,7 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
             # symbol for this step (i.e., teacher forcing).
             if teacher_forcing:
                 decoder_input = target[:, t].unsqueeze(1)
-            # Otherwise, it we pass the top pred to the next next 
+            # Otherwise, it we pass the top pred to the next next
             # timestep (i.e., student forcing, greedy decoding).
             else:
                 decoder_input = self._get_predicted(output)
@@ -254,10 +254,12 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
                     finished, (decoder_input == self.end_idx)
                 )
                 # Breaks when all batches predicted an EOS symbol.
-                # If we have a target (and are thus computing loss), 
-                # we only break when we have decoded at least the the 
+                # If we have a target (and are thus computing loss),
+                # we only break when we have decoded at least the the
                 # same number of steps as the target length.
-                if finished.all() and (target is None or decoder_input.size(-1) >= target.size(-1)):
+                if finished.all() and (
+                    target is None or decoder_input.size(-1) >= target.size(-1)
+                ):
                     break
         predictions = torch.stack(predictions)
         return predictions
@@ -412,7 +414,11 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
             )
         else:
             predictions = self.decode(
-                len(batch), batch.source.mask, encoder_out, batch.target.padded, teacher_forcing
+                len(batch),
+                batch.source.mask,
+                encoder_out,
+                batch.target.padded,
+                teacher_forcing,
             )
         # -> B x seq_len x output_size.
         predictions = predictions.transpose(0, 1)

--- a/yoyodyne/models/lstm.py
+++ b/yoyodyne/models/lstm.py
@@ -212,7 +212,8 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
             encoder_out (torch.Tensor): batch of encoded inputs.
             target (torch.Tensor, optional): target symbols; if None, then we
                 decode greedily with 'student forcing'.
-            teacher_forcing (bool, optional): Whether or not to decode with teacher forcing.
+            teacher_forcing (bool, optional): Whether or not to decode
+                with teacher forcing.
 
         Returns:
             predictions (torch.Tensor): tensor of predictions of shape
@@ -398,7 +399,8 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
 
         Args:
             batch (batches.PaddedBatch).
-            teacher_forcing (bool, optional): Whether or not to decode with teacher forcing.
+            teacher_forcing (bool, optional): Whether or not to decode
+                with teacher forcing.
 
         Returns:
             predictions (torch.Tensor): tensor of predictions of shape

--- a/yoyodyne/models/lstm.py
+++ b/yoyodyne/models/lstm.py
@@ -199,7 +199,7 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
         encoder_mask: torch.Tensor,
         encoder_out: torch.Tensor,
         target: Optional[torch.Tensor] = None,
-        teacher_forcing: Optional[bool] = True,
+        teacher_forcing: bool = True,
     ) -> torch.Tensor:
         """Decodes a sequence given the encoded input.
 
@@ -242,12 +242,12 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
                 decoder_input, decoder_hiddens, encoder_out, encoder_mask
             )
             predictions.append(output.squeeze(1))
-            # In teacher forcing mode the next input is the gold
-            # symbol for this step (i.e., teacher forcing).
+            # In teacher forcing mode the next input is the gold symbol
+            # for this step.
             if teacher_forcing:
                 decoder_input = target[:, t].unsqueeze(1)
-            # Otherwise, it we pass the top pred to the next next
-            # timestep (i.e., student forcing, greedy decoding).
+            # Otherwise we pass the top pred to the next timestep
+            # (i.e., student forcing, greedy decoding).
             else:
                 decoder_input = self._get_predicted(output)
                 # Updates to track which sequences have decoded an EOS.
@@ -258,10 +258,11 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
                 # If we have a target (and are thus computing loss),
                 # we only break when we have decoded at least the the
                 # same number of steps as the target length.
-                if finished.all() and (
-                    target is None or decoder_input.size(-1) >= target.size(-1)
-                ):
-                    break
+                if finished.all():
+                    if target is None or decoder_input.size(-1) >= target.size(
+                        -1
+                    ):
+                        break
         predictions = torch.stack(predictions)
         return predictions
 
@@ -393,7 +394,7 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
     def forward(
         self,
         batch: batches.PaddedBatch,
-        teacher_forcing: Optional[bool] = True,
+        teacher_forcing: bool = True,
     ) -> torch.Tensor:
         """Runs the encoder-decoder model.
 

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -217,6 +217,9 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
             # In teacher forcing mode the next input is the gold symbol
             # for this step.
             if teacher_forcing:
+                assert (
+                    target is not None
+                ), "Teacher forcing requested but no target provided"
                 decoder_input = target[:, t].unsqueeze(1)
             # Otherwise we pass the top pred to the next timestep
             # (i.e., student forcing, greedy decoding).
@@ -507,6 +510,9 @@ class PointerGeneratorLSTMEncoderDecoderFeatures(
             # In teacher forcing mode the next input is the gold symbol
             # for this step.
             if teacher_forcing:
+                assert (
+                    target is not None
+                ), "Teacher forcing requested but no target provided"
                 decoder_input = target[:, t].unsqueeze(1)
             # Otherwise we pass the top pred to the next timestep
             # (i.e., student forcing, greedy decoding).

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -209,7 +209,7 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
             # symbol for this step (i.e., teacher forcing).
             if teacher_forcing:
                 decoder_input = target[:, t].unsqueeze(1)
-            # Otherwise, it we pass the top pred to the next next 
+            # Otherwise, it we pass the top pred to the next next
             # timestep (i.e., student forcing, greedy decoding).
             else:
                 decoder_input = self._get_predicted(output)
@@ -218,10 +218,12 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
                     finished, (decoder_input == self.end_idx)
                 )
                 # Breaks when all batches predicted an EOS symbol.
-                # If we have a target (and are thus computing loss), 
-                # we only break when we have decoded at least the the 
+                # If we have a target (and are thus computing loss),
+                # we only break when we have decoded at least the the
                 # same number of steps as the target length.
-                if finished.all() and (target is None or decoder_input.size(-1) >= target.size(-1)):
+                if finished.all() and (
+                    target is None or decoder_input.size(-1) >= target.size(-1)
+                ):
                     break
         predictions = torch.stack(predictions)
         return predictions
@@ -235,7 +237,8 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
 
         Args:
             batch (batches.PaddedBatch).
-            teacher_forcing (bool, optional): Whether or not to decode with teacher forcing.
+            teacher_forcing (bool, optional): Whether or not to decode
+                with teacher forcing.
 
         Returns:
             torch.Tensor.
@@ -491,7 +494,7 @@ class PointerGeneratorLSTMEncoderDecoderFeatures(
             # symbol for this step (i.e., teacher forcing).
             if teacher_forcing:
                 decoder_input = target[:, t].unsqueeze(1)
-            # Otherwise, it we pass the top pred to the next next 
+            # Otherwise, it we pass the top pred to the next next
             # timestep (i.e., student forcing, greedy decoding).
             else:
                 decoder_input = self._get_predicted(output)
@@ -500,10 +503,12 @@ class PointerGeneratorLSTMEncoderDecoderFeatures(
                     finished, (decoder_input == self.end_idx)
                 )
                 # Breaks when all batches predicted an EOS symbol.
-                # If we have a target (and are thus computing loss), 
-                # we only break when we have decoded at least the the 
+                # If we have a target (and are thus computing loss),
+                # we only break when we have decoded at least the the
                 # same number of steps as the target length.
-                if finished.all() and (target is None or decoder_input.size(-1) >= target.size(-1)):
+                if finished.all() and (
+                    target is None or decoder_input.size(-1) >= target.size(-1)
+                ):
                     break
         predictions = torch.stack(predictions)
         return predictions
@@ -517,7 +522,8 @@ class PointerGeneratorLSTMEncoderDecoderFeatures(
 
         Args:
             batch (batches.PaddedBatch).
-            teacher_forcing (bool, optional): Whether or not to decode with teacher forcing.
+            teacher_forcing (bool, optional): Whether or not to decode
+                with teacher forcing.
 
         Returns:
             torch.Tensor.

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -164,7 +164,7 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
         source_enc: torch.Tensor,
         source_mask: torch.Tensor,
         target: Optional[torch.Tensor] = None,
-        teacher_forcing: Optional[bool] = True,
+        teacher_forcing: bool = True,
     ) -> torch.Tensor:
         """Decodes a sequence.
 
@@ -205,12 +205,12 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
                 source_mask,
             )
             predictions.append(output.squeeze(1))
-            # In teacher forcing mode the next input is the gold
-            # symbol for this step (i.e., teacher forcing).
+            # In teacher forcing mode the next input is the gold symbol
+            # for this step.
             if teacher_forcing:
                 decoder_input = target[:, t].unsqueeze(1)
-            # Otherwise, it we pass the top pred to the next next
-            # timestep (i.e., student forcing, greedy decoding).
+            # Otherwise we pass the top pred to the next timestep
+            # (i.e., student forcing, greedy decoding).
             else:
                 decoder_input = self._get_predicted(output)
                 # Tracks which sequences have decoded an EOS.
@@ -231,7 +231,7 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
     def forward(
         self,
         batch: batches.PaddedBatch,
-        teacher_forcing: Optional[bool] = True,
+        teacher_forcing: bool = True,
     ) -> torch.Tensor:
         """Runs the encoder-decoder.
 
@@ -443,7 +443,7 @@ class PointerGeneratorLSTMEncoderDecoderFeatures(
         feature_enc: torch.Tensor,
         feature_mask: torch.Tensor,
         target: Optional[torch.Tensor] = None,
-        teacher_forcing: Optional[bool] = True,
+        teacher_forcing: bool = True,
     ) -> torch.Tensor:
         """Decodes a sequence.
 
@@ -488,14 +488,12 @@ class PointerGeneratorLSTMEncoderDecoderFeatures(
                 feature_mask,
             )
             predictions.append(output.squeeze(1))
-            # If we have a target (training) then the next input is the gold
-            # symbol for this step (teacher forcing).
-            # In teacher forcing mode the next input is the gold
-            # symbol for this step (i.e., teacher forcing).
+            # In teacher forcing mode the next input is the gold symbol
+            # for this step.
             if teacher_forcing:
                 decoder_input = target[:, t].unsqueeze(1)
-            # Otherwise, it we pass the top pred to the next next
-            # timestep (i.e., student forcing, greedy decoding).
+            # Otherwise we pass the top pred to the next timestep
+            # (i.e., student forcing, greedy decoding).
             else:
                 decoder_input = self._get_predicted(output)
                 # Tracks which sequences have decoded an EOS.
@@ -506,17 +504,18 @@ class PointerGeneratorLSTMEncoderDecoderFeatures(
                 # If we have a target (and are thus computing loss),
                 # we only break when we have decoded at least the the
                 # same number of steps as the target length.
-                if finished.all() and (
-                    target is None or decoder_input.size(-1) >= target.size(-1)
-                ):
-                    break
+                if finished.all():
+                    if target is None or decoder_input.size(-1) >= target.size(
+                        -1
+                    ):
+                        break
         predictions = torch.stack(predictions)
         return predictions
 
     def forward(
         self,
         batch: batches.PaddedBatch,
-        teacher_forcing: Optional[bool] = True,
+        teacher_forcing: bool = True,
     ) -> torch.Tensor:
         """Runs the encoder-decoder.
 

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -63,7 +63,7 @@ class TransducerNoFeatures(lstm.LSTMEncoderDecoder):
     def forward(
         self,
         batch: batches.PaddedBatch,
-        teacher_forcing: Optional[bool] = True,
+        teacher_forcing: bool = True,
     ) -> Tuple[List[List[int]], torch.Tensor]:
         """Runs the encoder-decoder model.
 
@@ -100,7 +100,7 @@ class TransducerNoFeatures(lstm.LSTMEncoderDecoder):
         source_mask: torch.Tensor,
         target: Optional[torch.Tensor] = None,
         target_mask: Optional[torch.Tensor] = None,
-        teacher_forcing: Optional[bool] = True,
+        teacher_forcing: bool = True,
     ) -> Tuple[List[List[int]], torch.Tensor]:
         """Decodes a sequence given the encoded input.
 
@@ -614,7 +614,7 @@ class TransducerFeatures(TransducerNoFeatures):
     def forward(
         self,
         batch: batches.PaddedBatch,
-        teacher_forcing: Optional[bool] = True,
+        teacher_forcing: bool = True,
     ) -> torch.Tensor:
         """Runs the encoder-decoder model.
 

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -61,14 +61,17 @@ class TransducerNoFeatures(lstm.LSTMEncoderDecoder):
         )
 
     def forward(
-        self, batch: batches.PaddedBatch, teacher_forcing: Optional[bool] = True
+        self,
+        batch: batches.PaddedBatch,
+        teacher_forcing: Optional[bool] = True,
     ) -> Tuple[List[List[int]], torch.Tensor]:
         """Runs the encoder-decoder model.
 
         Args:
             batch (batches.PaddedBatch).
-            teacher_forcing (bool, optional): Whether or not to decode with teacher forcing.
-                Determines whether or not to rollout optimal actions.
+            teacher_forcing (bool, optional): Whether or not to decode
+                with teacher forcing. Determines whether or not to rollout
+                optimal actions.
 
         Returns:
             Tuple[List[List[int]], torch.Tensor] of encoded prediction values
@@ -110,8 +113,9 @@ class TransducerNoFeatures(lstm.LSTMEncoderDecoder):
             source_mask (torch.Tensor): mask for source input.
             target (torch.Tensor, optional): encoded target input.
             target_mask (torch.Tensor, optional): mask for target input.
-            teacher_forcing (bool, optional): Whether or not to decode with teacher forcing.
-                Determines whether or not to rollout optimal actions.
+            teacher_forcing (bool, optional): Whether or not to decode
+                with teacher forcing. Determines whether or not to rollout
+                optimal actions.
 
         Returns:
             Tuple[List[List[int]], torch.Tensor]: encoded prediction values
@@ -607,13 +611,18 @@ class TransducerFeatures(TransducerNoFeatures):
             batch_first=True,
         )
 
-    def forward(self, batch: batches.PaddedBatch, teacher_forcing: Optional[bool] = True) -> torch.Tensor:
+    def forward(
+        self,
+        batch: batches.PaddedBatch,
+        teacher_forcing: Optional[bool] = True,
+    ) -> torch.Tensor:
         """Runs the encoder-decoder model.
 
         Args:
             batch (batches.PaddedBatch).
-            teacher_forcing (bool, optional): Whether or not to decode with teacher forcing.
-                Determines whether or not to rollout optimal actions.
+            teacher_forcing (bool, optional): Whether or not to decode
+                with teacher forcing. Determines whether or not to rollout
+                optimal actions.
 
         Returns:
             Tuple[List[List[int]], torch.Tensor]: encoded prediction values

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -61,12 +61,14 @@ class TransducerNoFeatures(lstm.LSTMEncoderDecoder):
         )
 
     def forward(
-        self, batch: batches.PaddedBatch
+        self, batch: batches.PaddedBatch, teacher_forcing: Optional[bool] = True
     ) -> Tuple[List[List[int]], torch.Tensor]:
         """Runs the encoder-decoder model.
 
         Args:
             batch (batches.PaddedBatch).
+            teacher_forcing (bool, optional): Whether or not to decode with teacher forcing.
+                Determines whether or not to rollout optimal actions.
 
         Returns:
             Tuple[List[List[int]], torch.Tensor] of encoded prediction values
@@ -84,6 +86,7 @@ class TransducerNoFeatures(lstm.LSTMEncoderDecoder):
             source_mask,
             target=batch.target.padded,
             target_mask=batch.target.mask,
+            teacher_forcing=teacher_forcing,
         )
         return prediction, loss
 
@@ -94,6 +97,7 @@ class TransducerNoFeatures(lstm.LSTMEncoderDecoder):
         source_mask: torch.Tensor,
         target: Optional[torch.Tensor] = None,
         target_mask: Optional[torch.Tensor] = None,
+        teacher_forcing: Optional[bool] = True,
     ) -> Tuple[List[List[int]], torch.Tensor]:
         """Decodes a sequence given the encoded input.
 
@@ -106,6 +110,8 @@ class TransducerNoFeatures(lstm.LSTMEncoderDecoder):
             source_mask (torch.Tensor): mask for source input.
             target (torch.Tensor, optional): encoded target input.
             target_mask (torch.Tensor, optional): mask for target input.
+            teacher_forcing (bool, optional): Whether or not to decode with teacher forcing.
+                Determines whether or not to rollout optimal actions.
 
         Returns:
             Tuple[List[List[int]], torch.Tensor]: encoded prediction values
@@ -161,7 +167,7 @@ class TransducerNoFeatures(lstm.LSTMEncoderDecoder):
                 self.batch_expert_rollout(
                     source, target, alignment, prediction, not_complete
                 )
-                if target is not None
+                if teacher_forcing and target is not None
                 else None
             )
             last_action = self.decode_action_step(
@@ -601,11 +607,13 @@ class TransducerFeatures(TransducerNoFeatures):
             batch_first=True,
         )
 
-    def forward(self, batch: batches.PaddedBatch) -> torch.Tensor:
+    def forward(self, batch: batches.PaddedBatch, teacher_forcing: Optional[bool] = True) -> torch.Tensor:
         """Runs the encoder-decoder model.
 
         Args:
             batch (batches.PaddedBatch).
+            teacher_forcing (bool, optional): Whether or not to decode with teacher forcing.
+                Determines whether or not to rollout optimal actions.
 
         Returns:
             Tuple[List[List[int]], torch.Tensor]: encoded prediction values
@@ -648,6 +656,7 @@ class TransducerFeatures(TransducerNoFeatures):
             source_mask,
             target=batch.target.padded,
             target_mask=batch.target.mask,
+            teacher_forcing=teacher_forcing,
         )
         return prediction, loss
 

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -191,16 +191,17 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
         self,
         encoder_hidden: torch.Tensor,
         source_mask: torch.Tensor,
-        targets: Optional[torch.Tensor]
+        targets: Optional[torch.Tensor],
     ) -> torch.Tensor:
         """Decodes the output sequence greedily.
 
         Args:
             encoder_hidden (torch.Tensor): Hidden states from the encoder.
             source_mask (torch.Tensor): Mask for the encoded source tokens.
-            targets (torch.Tensor, optional): The optional target tokens, which is only used
-                for early stopping during validation if the decoder has predicted [EOS] for 
-                every sequence in the batch.
+            targets (torch.Tensor, optional): The optional target tokens,
+                which is only used for early stopping during validation
+                if the decoder has predicted [EOS] for every sequence in
+                the batch.
 
         Returns:
             torch.Tensor: predicitons from the decoder.
@@ -236,10 +237,12 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
                 finished, (predictions[-1] == self.end_idx)
             )
             # Breaks when all batches predicted an EOS symbol.
-            # If we have a target (and are thus computing loss), 
-            # we only break when we have decoded at least the the 
+            # If we have a target (and are thus computing loss),
+            # we only break when we have decoded at least the the
             # same number of steps as the target length.
-            if finished.all() and (targets is None or len(outputs) >= targets.size(-1)):
+            if finished.all() and (
+                targets is None or len(outputs) >= targets.size(-1)
+            ):
                 break
         # -> B x seq_len x output_size.
         return torch.stack(outputs).transpose(0, 1)
@@ -280,7 +283,9 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
         else:
             encoder_hidden = self.encode(batch.source)
             # -> B x seq_len x output_size.
-            output = self._decode_greedy(encoder_hidden, batch.source.mask, batch.target.padded)
+            output = self._decode_greedy(
+                encoder_hidden, batch.source.mask, batch.target.padded
+            )
         return output
 
     @staticmethod

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -249,19 +249,16 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
     def forward(
         self,
         batch: batches.PaddedBatch,
-        teacher_forcing: bool = True,
     ) -> torch.Tensor:
         """Runs the encoder-decoder.
 
         Args:
             batch (batches.PaddedBatch).
-            teacher_forcing (bool, optional): Whether or not to decode
-                with teacher forcing.
 
         Returns:
             torch.Tensor.
         """
-        if teacher_forcing:
+        if self.training and self.teacher_forcing:
             # Initializes the start symbol for decoding.
             starts = (
                 torch.tensor(

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -240,17 +240,16 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
             # If we have a target (and are thus computing loss),
             # we only break when we have decoded at least the the
             # same number of steps as the target length.
-            if finished.all() and (
-                targets is None or len(outputs) >= targets.size(-1)
-            ):
-                break
+            if finished.all():
+                if targets is None or len(outputs) >= targets.size(-1):
+                    break
         # -> B x seq_len x output_size.
         return torch.stack(outputs).transpose(0, 1)
 
     def forward(
         self,
         batch: batches.PaddedBatch,
-        teacher_forcing: Optional[bool] = True,
+        teacher_forcing: bool = True,
     ) -> torch.Tensor:
         """Runs the encoder-decoder.
 

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -256,7 +256,8 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
 
         Args:
             batch (batches.PaddedBatch).
-            teacher_forcing (bool, optional): Whether or not to decode with teacher forcing.
+            teacher_forcing (bool, optional): Whether or not to decode
+                with teacher forcing.
 
         Returns:
             torch.Tensor.

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -204,7 +204,7 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
                 the batch.
 
         Returns:
-            torch.Tensor: predicitons from the decoder.
+            torch.Tensor: predictions from the decoder.
         """
         # The output distributions to be returned.
         outputs = []
@@ -259,6 +259,9 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
             torch.Tensor.
         """
         if self.training and self.teacher_forcing:
+            assert (
+                batch.target.padded is not None
+            ), "Teacher forcing requested but no target provided"
             # Initializes the start symbol for decoding.
             starts = (
                 torch.tensor(


### PR DESCRIPTION
- Updates validation step to only call model forawrd once.
- Adds teacher_forcing param to  forward and decode methods.
- Calls validation step with teacher_forcing=False.
- Updates  methods to decode until EOS AND at least length of target in teacher_forcing mode.
- Calls predict step with teacher_forcing=False.


Closes #70 

Adds `teacher_forcing`, which tells the model to decode using the gold history, rather than the predicted history. This is typically how encoder-decoder inflection models are trained, but during validation/prediction, we force teacher_forcing to be False.

I additionally implemented a check that makes validation more efficient: we supply the target tensor, but only use it for early stopping on decoding if the decoder has predicted an EOS token for every sequence in the batch. This ensures that we can decode greedily up to at least the length of the targets, and then compute a loss in which we need `len(predicted == len(targets)`.

*IMPORTANT* 
- For Transducer, teacher_forcing means we get the gold actions from the expert. @bonham79 does this make sense? Or should I ignore this new parameter entirely in that architecture?
- Transducer errors with:

```
  File "/Users/adamwiemerslage/nlp-projects/morphology/yoyodyne/yoyodyne/models/expert.py", line 105, in lookup
    return self.w2i[word]
KeyError: ConditionalIns(new=0)
```

I reverted all changes to test, and still reproduce the error. This is on the ConLL-SIGMORPHON 2017 inflection shared task English medium setting data, with the dev set. I suspect this is related to an old issue that happened when there was an OOV in the eval set. @bonham79 -- do you know if that issue still exists in the transducer?