### PR TITLE
Fixes predict no target

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Alternatively, for the SIGMORPHON 2016 shared task data format:
 
 this format is specified by `--features-col 2 --features-sep , --target-col 3`.
 
+In order to ensure that targets are ignored during prediction, one can specify `--target_col 0`.
+
 ## Model checkpointing
 
 Checkpointing is handled by

--- a/yoyodyne/dataconfig.py
+++ b/yoyodyne/dataconfig.py
@@ -130,6 +130,24 @@ class DataConfig:
                 target = self._get_cell(row, self.target_col, self.target_sep)
                 yield source, features, target
 
+    def source_features_samples(
+        self, filename: str
+    ) -> Iterator[Tuple[List[str], List[str]]]:
+        """Yields source, and features."""
+        with open(filename, "r") as source:
+            tsv_reader = csv.reader(source, delimiter="\t")
+            for row in tsv_reader:
+                source = self._get_cell(row, self.source_col, self.source_sep)
+                # Avoids overlap with source.
+                features = [
+                    f"[{feature}]"
+                    for feature in self._get_cell(
+                        row, self.features_col, self.features_sep
+                    )
+                ]
+                yield source, features
+
+
     def samples(self, filename: str) -> Iterator[Tuple[List[str], ...]]:
         """Picks the right one for this config."""
         if self.has_features:

--- a/yoyodyne/datasets.py
+++ b/yoyodyne/datasets.py
@@ -254,7 +254,10 @@ class DatasetNoFeatures(BaseDataset):
         Returns:
             Item.
         """
-        source, target = self.samples[idx]
+        if self.config.has_target:
+            source, target = self.samples[idx]
+        else:
+            source = self.samples[idx]
         source_encoded = self.encode(self.index.source_map, source)
         if self.config.has_target:
             target_encoded = self.encode(
@@ -321,7 +324,11 @@ class DatasetFeatures(DatasetNoFeatures):
         Returns:
             Item.
         """
-        source, features, target = self.samples[idx]
+        if self.config.has_target:
+            source, features, target = self.samples[idx]
+        else:
+            source, features = self.samples[idx]
+
         source_encoded = self.encode(self.index.source_map, source)
         features_encoded = self.encode(
             self.index.features_map,

--- a/yoyodyne/models/lstm.py
+++ b/yoyodyne/models/lstm.py
@@ -423,7 +423,7 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
                 batch.source.mask,
                 encoder_out,
                 self.teacher_forcing if self.training else False,
-                batch.target.padded,
+                batch.target.padded if batch.target else None,
             )
         # -> B x seq_len x output_size.
         predictions = predictions.transpose(0, 1)

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -269,7 +269,7 @@ class PointerGeneratorLSTMEncoderDecoderNoFeatures(lstm.LSTMEncoderDecoder):
                 source_encoded,
                 batch.source.mask,
                 self.teacher_forcing if self.training else False,
-                batch.target.padded,
+                batch.target.padded if batch.target else None,
             )
         # -> B x seq_len x output_size.
         predictions = predictions.transpose(0, 1)
@@ -576,7 +576,7 @@ class PointerGeneratorLSTMEncoderDecoderFeatures(
                 features_encoded,
                 batch.features.mask,
                 self.teacher_forcing if self.training else False,
-                batch.target.padded,
+                batch.target.padded if batch.target else None,
             )
         # -> B x seq_len x output_size.
         predictions = predictions.transpose(0, 1)

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -84,7 +84,7 @@ class TransducerNoFeatures(lstm.LSTMEncoderDecoder):
             source_padded,
             source_mask,
             teacher_forcing=self.teacher_forcing if self.training else False,
-            target=batch.target.padded,
+            target=batch.target.padded if batch.target else None,
             target_mask=batch.target.mask,
         )
         return prediction, loss
@@ -640,7 +640,7 @@ class TransducerFeatures(TransducerNoFeatures):
             source_padded,
             source_mask,
             teacher_forcing=self.teacher_forcing if self.training else False,
-            target=batch.target.padded,
+            target=batch.target.padded if batch.target else None,
             target_mask=batch.target.mask,
         )
         return prediction, loss

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -284,7 +284,9 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
             encoder_hidden = self.encode(batch.source)
             # -> B x seq_len x output_size.
             output = self._decode_greedy(
-                encoder_hidden, batch.source.mask, batch.target.padded
+                encoder_hidden,
+                batch.source.mask,
+                batch.target.padded if batch.target else None,
             )
         return output
 


### PR DESCRIPTION
Adds the non-existant (but still called -- oh the perils of writing software in interpreted languages!) `source_features_samples`, and makes fixes for when no target is passed through.

Also adds @kylebgorman's suggestion for passing `batch.target.padded` to `decode` when there is no target.