### PR TITLE
More precision in checkpoint names

### DIFF
--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -65,7 +65,7 @@ def _get_callbacks(save_top_k: int, patience: Optional[int] = None) -> List:
             save_top_k=save_top_k,
             monitor="val_accuracy",
             mode="max",
-            filename="model-{epoch:02d}-{val_accuracy:.2f}",
+            filename="model-{epoch:03d}-{val_accuracy:.3f}",
         ),
         callbacks.LearningRateMonitor(logging_interval="epoch"),
         callbacks.TQDMProgressBar(),


### PR DESCRIPTION
This saves the checkpoint accuracies to 3 digits instead of 2, and stores 3-digit epoch counts.