### PR TITLE
Better support for not parsing irrelevant fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,22 +64,24 @@ must specify the following required arguments:
 -   `--train`: path to TSV file containing training data
 -   `--val`: path to TSV file containing validation data
 
-The user can also specify various optional training and architectural
-arguments. See below or run [`yoyodyne-train --help`](yoyodyne/train.py) for
-more information.
+The user can also specify various optional training and architectural arguments.
+See below or run [`yoyodyne-train --help`](yoyodyne/train.py) for more
+information.
 
 ### Prediction
 
-Prediction is performed by the [`yoyodyne-predict`](yoyodyne/predict.py)
-script. One must specify the following required arguments:
+Prediction is performed by the [`yoyodyne-predict`](yoyodyne/predict.py) script.
+One must specify the following required arguments:
 
 -   `--model_dir`: path for model metadata
 -   `--experiment`: name of experiment
 -   `--checkpoint`: path to checkpoint
--   `--predict`: path to TSV file containing data to be predicted
+-   `--predict`: path to file containing data to be predicted
 -   `--output`: path for predictions
 
-Run [`yoyodyne-predict --help`](yoyodyne/predict.py) for more information.
+The `--predict` file can either be a TSV file or an ordinary TXT file with one
+source string per line; in the latter case, specify `--target_col 0`. Run
+[`yoyodyne-predict --help`](yoyodyne/predict.py) for more information.
 
 ## Data format
 

--- a/yoyodyne/data/datamodules.py
+++ b/yoyodyne/data/datamodules.py
@@ -64,11 +64,11 @@ class DataModule(pl.LightningDataModule):
         )
         self.collator = collators.Collator(
             pad_idx=self.index.pad_idx,
-            has_features=self.index.has_features,
-            has_target=self.index.has_target,
+            has_features=self.has_features,
+            has_target=self.has_target,
             separate_features=separate_features,
             features_offset=self.index.source_vocab_size
-            if self.index.has_features
+            if self.has_features
             else 0,
             max_source_length=max_source_length,
             max_target_length=max_target_length,
@@ -80,8 +80,8 @@ class DataModule(pl.LightningDataModule):
         features_vocabulary: Set[str] = set()
         target_vocabulary: Set[str] = set()
         for path in self.paths:
-            if self.parser.has_features:
-                if self.parser.has_target:
+            if self.has_features:
+                if self.has_target:
                     for source, features, target in self.parser.samples(path):
                         source_vocabulary.update(source)
                         features_vocabulary.update(features)
@@ -90,14 +90,14 @@ class DataModule(pl.LightningDataModule):
                     for source, features in self.parser.samples(path):
                         source_vocabulary.update(source)
                         features_vocabulary.update(features)
-            elif self.parser.has_target:
+            elif self.has_target:
                 for source, target in self.parser.samples(path):
                     source_vocabulary.update(source)
                     target_vocabulary.update(target)
             else:
                 for source in self.parser.samples(path):
                     source_vocabulary.update(source)
-            if self.parser.has_target and tied_vocabulary:
+            if self.has_target and tied_vocabulary:
                 source_vocabulary.update(target_vocabulary)
                 target_vocabulary.update(source_vocabulary)
         return indexes.Index(
@@ -126,11 +126,11 @@ class DataModule(pl.LightningDataModule):
     def log_vocabularies(self) -> None:
         """Logs this module's vocabularies."""
         util.log_info(f"Source vocabulary: {self.index.source_map.pprint()}")
-        if self.index.has_features:
+        if self.has_features:
             util.log_info(
                 f"Features vocabulary: {self.index.features_map.pprint()}"
             )
-        if self.index.has_target:
+        if self.has_target:
             util.log_info(
                 f"Target vocabulary: {self.index.target_map.pprint()}"
             )
@@ -141,11 +141,11 @@ class DataModule(pl.LightningDataModule):
 
     @property
     def has_features(self) -> int:
-        return self.index.has_features
+        return self.parser.has_features
 
     @property
     def has_target(self) -> int:
-        return self.index.has_target
+        return self.parser.has_target
 
     @property
     def source_vocab_size(self) -> int:

--- a/yoyodyne/data/datasets.py
+++ b/yoyodyne/data/datasets.py
@@ -58,11 +58,11 @@ class Dataset(data.Dataset):
 
     @property
     def has_features(self) -> bool:
-        return self.index.has_features
+        return self.parser.has_features
 
     @property
     def has_target(self) -> bool:
-        return self.index.has_target
+        return self.parser.has_target
 
     def _encode(
         self,
@@ -206,8 +206,8 @@ class Dataset(data.Dataset):
         Returns:
             Item.
         """
-        if self.index.has_features:
-            if self.index.has_target:
+        if self.has_features:
+            if self.has_target:
                 source, features, target = self.samples[idx]
                 return Item(
                     source=self.encode_source(source),
@@ -220,11 +220,12 @@ class Dataset(data.Dataset):
                     source=self.encode_source(source),
                     features=self.encode_features(features),
                 )
-        elif self.index.has_target:
+        elif self.has_target:
             source, target = self.samples[idx]
             return Item(
                 source=self.encode_source(source),
                 target=self.encode_target(target),
             )
         else:
+            source = self.samples[idx]
             return Item(source=self.encode_source(source))

--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -79,7 +79,7 @@ class Index:
             SymbolMap(features_vocabulary) if features_vocabulary else None
         )
         self.target_map = (
-            SymbolMap(target_vocabulary) if source_vocabulary else None
+            SymbolMap(target_vocabulary) if target_vocabulary else None
         )
 
     # Serialization support.

--- a/yoyodyne/data/tsv.py
+++ b/yoyodyne/data/tsv.py
@@ -53,8 +53,6 @@ class TsvParser:
             raise Error(f"Out of range source column: {self.source_col}")
         if self.features_col < 0:
             raise Error(f"Out of range features column: {self.features_col}")
-        if self.features_col < 0:
-            raise Error(f"Out of range features column: {self.features_col}")
         if self.target_col < 0:
             raise Error(f"Out of range target column: {self.target_col}")
 

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -124,6 +124,8 @@ def get_datamodule_from_argparse_args(
         max_source_length=args.max_source_length,
         max_target_length=args.max_target_length,
     )
+    if not datamodule.has_target:
+        raise Error("No target column specified")
     datamodule.index.write(args.model_dir, args.experiment)
     datamodule.log_vocabularies()
     return datamodule


### PR DESCRIPTION
This makes it so that `yoyodyne-predict` works with `--features_col 0`. That is, if this is specified it doesn't bother to parse the features column at all, which saves you a little time.

It does this by delegating `has_features` and `has_target` to the parser rather than to the index, and fixes a sneaky bug on the last line of the datasets module.