### PR TITLE
Silences warning about multiple WandB loggers

### DIFF
--- a/examples/wandb_sweeps/train_wandb_sweep.py
+++ b/examples/wandb_sweeps/train_wandb_sweep.py
@@ -4,11 +4,15 @@
 import argparse
 import functools
 import traceback
+import warnings
 
 import pytorch_lightning as pl
 import wandb
 
 from yoyodyne import train, util
+
+
+warnings.filterwarnings("ignore", ".*is a wandb run already in progress.*")
 
 
 class Error(Exception):


### PR DESCRIPTION
As I understand it this is not the warning discussed in #78 but it's good to silence anyways.

The full error reads:

```
UserWarning: There is a wandb run already in progress and newly created instances of `WandbLogger` will reuse this run. If this is not desired, call `wandb.finish()` before instantiating `WandbLogger`.
```

@Adamits please let me konw if we want this.