### PR TITLE
WIP: Fixes eval accuracy on epoch

### DIFF
--- a/yoyodyne/evaluators.py
+++ b/yoyodyne/evaluators.py
@@ -1,7 +1,7 @@
 """Evaluators."""
 
 from __future__ import annotations
-from dataclasses import dataclass
+import dataclasses
 
 import torch
 from torch.nn import functional
@@ -11,7 +11,7 @@ class Error(Exception):
     pass
 
 
-@dataclass
+@dataclasses.dataclass
 class EvalItem:
     num_correct: int
     num_predicted: int
@@ -36,11 +36,11 @@ class EvalItem:
         )
 
     def __radd__(self, start_val: int) -> EvalItem:
-        """The initial add when calling `sum` on an iterable of EvalItems.
-        A zero values start value is provided.
+        """Reverse add. Expects a zero-valued integer.
 
         Args:
-            start_val (int): A zero for calling the first add in an iterable.
+            start_val (int): An initial value for calling the first add in an
+                iterable. Expected to be 0.
 
         Returns:
             EvalItem.

--- a/yoyodyne/evaluators.py
+++ b/yoyodyne/evaluators.py
@@ -60,7 +60,7 @@ class Evaluator:
         )[0].size()[0]
         # Gets the batch size (total_count).
         total_count = predictions.size(0)
-        return corr_count / total_count
+        return corr_count, total_count, corr_count / total_count
 
     @staticmethod
     def finalize_predictions(

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -314,7 +314,6 @@ class BaseEncoderDecoder(pl.LightningModule):
             "val_loss": avg_val_loss,
             "val_accuracy": epoch_eval.accuracy,
         }
-
         for metric, value in metrics.items():
             self.log(metric, value, prog_bar=True)
         return metrics

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -533,11 +533,10 @@ class TransducerEncoderDecoder(lstm.LSTMEncoderDecoder):
         predictions = self.evaluator.finalize_predictions(
             predictions, self.end_idx, self.pad_idx
         )
-
-        correct, total, _ = self.evaluator.accuracy(
+        val_eval_item = self.evaluator.get_eval_item(
             predictions, batch.target.padded, self.pad_idx
         )
-        return {"val_correct": correct, "val_total": total, "val_loss": loss}
+        return {"val_eval_item": val_eval_item, "val_loss": loss}
 
     def predict_step(self, batch: Tuple[torch.tensor], batch_idx: int) -> Dict:
         predictions, _ = self.forward(

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -533,12 +533,11 @@ class TransducerEncoderDecoder(lstm.LSTMEncoderDecoder):
         predictions = self.evaluator.finalize_predictions(
             predictions, self.end_idx, self.pad_idx
         )
-        return {
-            "val_accuracy": self.evaluator.accuracy(
-                predictions, batch.target.padded, self.pad_idx
-            ),
-            "val_loss": loss,
-        }
+
+        correct, total, _ = self.evaluator.accuracy(
+            predictions, batch.target.padded, self.pad_idx
+        )
+        return {"val_correct": correct, "val_total": total, "val_loss": loss}
 
     def predict_step(self, batch: Tuple[torch.tensor], batch_idx: int) -> Dict:
         predictions, _ = self.forward(


### PR DESCRIPTION
Addresses #119

Marking this as a WIP as it's a little clunky, but wanted to get a PR up. Probably we should refactor the evaluator so the semantics of getting correct/total counts is clearer?

This fixes an issue where we report a macro accuracy over per-batch accuracies on the validation set, rather than a micro accuracy over all predictions. 