### PR TITLE
Loss function updates

### DIFF
--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -95,7 +95,7 @@ class BaseEncoderDecoder(pl.LightningModule):
         self.beta2 = beta2
         self.label_smoothing = label_smoothing
         self.learning_rate = learning_rate
-        self.loss_func = self._get_loss_func("mean")
+        self.loss_func = self._get_loss_func()
         self.optimizer = optimizer
         self.scheduler = scheduler
         self.scheduler_kwargs = scheduler_kwargs
@@ -428,63 +428,18 @@ class BaseEncoderDecoder(pl.LightningModule):
         return [scheduler_cfg]
 
     def _get_loss_func(
-        self, reduction: str
+        self,
     ) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
         """Returns the actual function used to compute loss.
-
-        Args:
-            reduction (str): reduction for the loss function (e.g., "mean").
 
         Returns:
             Callable[[torch.Tensor, torch.Tensor], torch.Tensor]: configured
                 loss function.
         """
-        # TODO(kbg): swap this out for CrossEntropyLoss?
-        if not self.label_smoothing:
-            return nn.NLLLoss(ignore_index=self.pad_idx, reduction=reduction)
-        else:
-            return self._smooth_nllloss
-
-    # TODO(kbg): use the label smoothing in CrossEntropyLoss.
-
-    def _smooth_nllloss(
-        self, predictions: torch.Tensor, target: torch.Tensor
-    ) -> torch.Tensor:
-        """After:
-
-            https://github.com/NVIDIA/DeepLearningExamples/blob/
-            8d8b21a933fff3defb692e0527fca15532da5dc6/PyTorch/Classification/
-            ConvNets/image_classification/smoothing.py#L18
-
-        Args:
-            predictions (torch.Tensor): tensor of prediction
-                distribution of shape B x target_vocab_size x seq_len.
-            target (torch.Tensor): tensor of golds of shape
-                B x seq_len.
-
-        Returns:
-            torch.Tensor: loss.
-        """
-        # -> (B * seq_len) x target_vocab_size.
-        predictions = predictions.transpose(1, 2).reshape(
-            -1, self.target_vocab_size
+        return nn.CrossEntropyLoss(
+            ignore_index=self.pad_idx,
+            label_smoothing=self.label_smoothing,
         )
-        # -> (B * seq_len) x 1.
-        target = target.view(-1, 1)
-        non_pad_mask = target.ne(self.pad_idx)
-        # Gets the ordinary loss.
-        nll_loss = -predictions.gather(dim=-1, index=target)[
-            non_pad_mask
-        ].mean()
-        # Gets the smoothed loss.
-        smooth_loss = -predictions.sum(dim=-1, keepdim=True)[
-            non_pad_mask
-        ].mean()
-        smooth_loss = smooth_loss / self.target_vocab_size
-        # Combines both according to label smoothing weight.
-        loss = (1.0 - self.label_smoothing) * nll_loss
-        loss.add_(self.label_smoothing * smooth_loss)
-        return loss
 
     @staticmethod
     def add_argparse_args(parser: argparse.ArgumentParser) -> None:

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -371,7 +371,7 @@ class PointerGeneratorLSTMEncoderDecoder(lstm.LSTMEncoderDecoder):
         return predictions
 
     def _get_loss_func(
-        self
+        self,
     ) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
         """Returns the actual function used to compute loss.
 

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -373,15 +373,13 @@ class PointerGeneratorLSTMEncoderDecoder(lstm.LSTMEncoderDecoder):
     def _get_loss_func(
         self,
     ) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
-        """Returns the actual function used to compute loss.After:
+        """Returns the actual function used to compute loss.
 
-        After:
-
-            This overrides the loss function behavior in
-            models.base.BaseEncoderDecoder because we need to use NLLLoss in
-            order to factor the addition of two seperate probability
-            distributions. Thus, we also add our own implementation of label
-            smoothing.
+        This overrides the loss function behavior in
+        models.base.BaseEncoderDecoder because we need to use NLLLoss in
+        order to factor the addition of two separate probability
+        distributions. An NLLLoss-compatible implementation of label smoothing
+        is also provided when label smoothing is requested.
 
         Returns:
             Callable[[torch.Tensor, torch.Tensor], torch.Tensor]: configured

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -387,8 +387,9 @@ class PointerGeneratorLSTMEncoderDecoder(lstm.LSTMEncoderDecoder):
     def _smooth_nllloss(
         self, predictions: torch.Tensor, target: torch.Tensor
     ) -> torch.Tensor:
-        """Computes the NLLLoss with a smoothing factor such that some proportion
-        of the output distribution is replaced with a uniform distribution.
+        """Computes the NLLLoss with a smoothing factor such that some
+        proportion of the output distribution is replaced with a
+        uniform distribution.
 
         After:
 

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -371,19 +371,16 @@ class PointerGeneratorLSTMEncoderDecoder(lstm.LSTMEncoderDecoder):
         return predictions
 
     def _get_loss_func(
-        self, reduction: str
+        self
     ) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
         """Returns the actual function used to compute loss.
-
-        Args:
-            reduction (str): reduction for the loss function (e.g., "mean").
 
         Returns:
             Callable[[torch.Tensor, torch.Tensor], torch.Tensor]: configured
                 loss function.
         """
         if not self.label_smoothing:
-            return nn.NLLLoss(ignore_index=self.pad_idx, reduction=reduction)
+            return nn.NLLLoss(ignore_index=self.pad_idx)
         else:
             return self._smooth_nllloss
 

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -387,8 +387,8 @@ class PointerGeneratorLSTMEncoderDecoder(lstm.LSTMEncoderDecoder):
     def _smooth_nllloss(
         self, predictions: torch.Tensor, target: torch.Tensor
     ) -> torch.Tensor:
-        """Computes the NLLLoss with a smoothing factor such that some proportion of
-        the output distribution is replaced with a uniform distribution.
+        """Computes the NLLLoss with a smoothing factor such that some proportion
+        of the output distribution is replaced with a uniform distribution.
 
         After:
 

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -373,7 +373,15 @@ class PointerGeneratorLSTMEncoderDecoder(lstm.LSTMEncoderDecoder):
     def _get_loss_func(
         self,
     ) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
-        """Returns the actual function used to compute loss.
+        """Returns the actual function used to compute loss.After:
+
+        After:
+
+            This overrides the loss function behavior in
+            models.base.BaseEncoderDecoder because we need to use NLLLoss in
+            order to factor the addition of two seperate probability
+            distributions. Thus, we also add our own implementation of label
+            smoothing.
 
         Returns:
             Callable[[torch.Tensor, torch.Tensor], torch.Tensor]: configured

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -17,7 +17,6 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
     attention_heads: int
     # Constructed inside __init__.
     classifier: nn.Linear
-    log_softmax: nn.LogSoftmax
 
     def __init__(
         self,
@@ -38,7 +37,6 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
         self.classifier = nn.Linear(
             self.embedding_size, self.target_vocab_size
         )
-        self.log_softmax = nn.LogSoftmax(dim=2)
 
     def get_decoder(self):
         return modules.transformer.TransformerDecoder(
@@ -95,8 +93,7 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
                 encoder_hidden, source_mask, target_tensor, target_mask
             ).output
             logits = self.classifier(decoder_output)
-            log_probs = self.log_softmax(logits)
-            last_output = log_probs[:, -1, :]  # Ignores EOS.
+            last_output = logits[:, -1, :]  # Ignores EOS.
             outputs.append(last_output)
             # -> B x 1 x 1
             _, pred = torch.max(last_output, dim=1)
@@ -148,8 +145,7 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
                 encoder_output, batch.source.mask, target_padded, target_mask
             ).output
             logits = self.classifier(decoder_output)
-            log_probs = self.log_softmax(logits)
-            output = log_probs[:, :-1, :]  # Ignore EOS.
+            output = logits[:, :-1, :]  # Ignore EOS.
         else:
             encoder_output = self.source_encoder(batch.source).output
             # -> B x seq_len x output_size.


### PR DESCRIPTION
- Changes loss functions to use `CrossEntropyLoss`.
- Overrides this for `PointerGenerator`, which needs to use `NLLLoss`
- Patches the main bug in #111