### PR TITLE
WIP: Adds transformer pointer generator.

### DIFF
--- a/yoyodyne/models/__init__.py
+++ b/yoyodyne/models/__init__.py
@@ -4,7 +4,10 @@ import argparse
 
 from .base import BaseEncoderDecoder
 from .lstm import AttentiveLSTMEncoderDecoder, LSTMEncoderDecoder
-from .pointer_generator import PointerGeneratorLSTMEncoderDecoder
+from .pointer_generator import (
+    PointerGeneratorLSTMEncoderDecoder,
+    PointerGeneratorTransformerEncoderDecoder,
+)
 from .transducer import TransducerEncoderDecoder
 from .transformer import TransformerEncoderDecoder
 
@@ -26,6 +29,7 @@ def get_model_cls(arch: str) -> BaseEncoderDecoder:
         "attentive_lstm": AttentiveLSTMEncoderDecoder,
         "lstm": LSTMEncoderDecoder,
         "pointer_generator_lstm": PointerGeneratorLSTMEncoderDecoder,
+        "pointer_generator_transformer": PointerGeneratorTransformerEncoderDecoder,
         "transducer": TransducerEncoderDecoder,
         "transformer": TransformerEncoderDecoder,
     }
@@ -67,6 +71,7 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
             "attentive_lstm",
             "lstm",
             "pointer_generator_lstm",
+            "pointer_generator_transformer",
             "transducer",
             "transformer",
         ],

--- a/yoyodyne/models/modules/__init__.py
+++ b/yoyodyne/models/modules/__init__.py
@@ -43,6 +43,7 @@ def get_encoder_cls(
         "attentive_lstm": LSTMEncoder,
         "lstm": LSTMEncoder,
         "pointer_generator_lstm": LSTMEncoder,
+        "pointer_generator_transformer": TransformerEncoder,
         "transducer": LSTMEncoder,
         "transformer": TransformerEncoder,
     }

--- a/yoyodyne/models/modules/base.py
+++ b/yoyodyne/models/modules/base.py
@@ -19,10 +19,15 @@ class ModuleOutput:
 
     output: torch.Tensor
     hiddens: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+    embeddings: Optional[torch.Tensor] = None
 
     @property
     def has_hiddens(self) -> bool:
         return self.hiddens is not None
+    
+    @property
+    def has_embeddings(self) -> bool:
+        return self.embeddings is not None
 
 
 class BaseModule(pl.LightningModule):


### PR DESCRIPTION
- Adds a pointer generator with a transformer encoder-decoder.
- Introduces a WIP TransformerDecoder that sets a hook to override the torch implementations default behavior of not returning the MHA weights.
- Uses the MHA weights to get pointer probabilities
- Currently does NOT handle features. I believe this will required a second multiheaded attention from each decoder step to the encoded source tokens.  I will note that this may require subclassing the torch `TransformerDecoder` to implement, which will make my work with the hook/`patch_attention` unneeded (we could just hardcode the behavior directly into the subclassed decoder). I have not thought about this much yet though.

This is a WIP, but has a working implementation as far as I can tell, for a transformer encoder-decoder when there are not features. teacher-forced training works by getting all pointer and generator distributions for each target, and then combining them in one go. Greedy decoding for inference works more like the LSTM, where we first decode a single target, then combine pointer and generator probabilities, and then iteratively do it again until we hit EOS or `max_target_length`.

Looking for any obvious mistakes or feedback on the general structure.