### PR TITLE
Fixes END accumulation. makes encode_target append to a copy.

### DIFF
--- a/yoyodyne/data/datasets.py
+++ b/yoyodyne/data/datasets.py
@@ -120,7 +120,7 @@ class Dataset(data.Dataset):
         Returns:
             torch.Tensor.
         """
-        wrapped = [s for s in symbols]
+        wrapped = symbols.copy()
         wrapped.append(special.END)
         return self._encode(wrapped, self.index.target_map)
 

--- a/yoyodyne/data/datasets.py
+++ b/yoyodyne/data/datasets.py
@@ -120,7 +120,7 @@ class Dataset(data.Dataset):
         Returns:
             torch.Tensor.
         """
-        wrapped = symbols
+        wrapped = [s for s in symbols]
         wrapped.append(special.END)
         return self._encode(wrapped, self.index.target_map)
 


### PR DESCRIPTION
We were adding the END token to a reference to the actual target sample every time we encoded it. When running some tests where I was evaluating a ton, I noticed that some eval samples would somehow become >128 (the max sequence length) causing an error. 

This ensures we append END to a copy of the target, so that between calls to __getitem__ we are no longer adding to the target token.