### PR TITLE
W&B no longer "logs" (uploads) checkpoints.

### DIFF
--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -30,6 +30,8 @@ def _get_logger(experiment: str, model_dir: str, log_wandb: bool) -> List:
         trainer_logger.append(loggers.WandbLogger(project=experiment))
         # Tells PTL to log the best validation accuracy.
         wandb.define_metric("val_accuracy", summary="max")
+        # Logs the path to local artifacts made by PTL.
+        wandb.config["local_run_dir"] = trainer_logger[0].log_dir
     return trainer_logger
 
 

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -27,13 +27,9 @@ def _get_logger(experiment: str, model_dir: str, log_wandb: bool) -> List:
     """
     trainer_logger = [loggers.CSVLogger(model_dir, name=experiment)]
     if log_wandb:
-        trainer_logger.append(
-            loggers.WandbLogger(project=experiment, log_model="all")
-        )
-        # Tells PTL to log best validation acc
+        trainer_logger.append(loggers.WandbLogger(project=experiment))
+        # Tells PTL to log the best validation accuracy.
         wandb.define_metric("val_accuracy", summary="max")
-        # Logs the path to local artifacts made by PTL.
-        wandb.config.update({"local_run_dir": trainer_logger[0].log_dir})
     return trainer_logger
 
 


### PR DESCRIPTION
I also remove some seemingly pointless logging of model paths; can restore if there's a reason we need this.

Note that there exist alternatives: for instance we can log any checkpoint that's an improvement. From [the docs](https://lightning.ai/docs/pytorch/stable/extensions/generated/lightning.pytorch.loggers.WandbLogger.html):

```python
# log model only if `val_accuracy` increases
wandb_logger = WandbLogger(log_model="all")
checkpoint_callback = ModelCheckpoint(monitor="val_accuracy", mode="max")
trainer = Trainer(logger=wandb_logger, callbacks=[checkpoint_callback])
```

But I think this would still be excessive and I can't imagine why you'd want to log a checkpoint on W&B, tbh.