### PR TITLE
Log model parameters to wandb

### DIFF
--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -326,7 +326,7 @@ def main() -> None:
     # Logs number of model parameters.
     if args.log_wandb:
         n_params = sum(p.numel() for p in model.parameters())
-        wandb.config.update({"n_model_params": n_params})
+        wandb.config["n_model_params"] = n_params
     # Tuning options. Batch autoscaling is unsupported; LR tuning logs the
     # suggested value and then exits.
     if args.auto_scale_batch_size:

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -325,10 +325,8 @@ def main() -> None:
     model = get_model_from_argparse_args(args, datamodule)
     # Logs number of model parameters.
     if args.log_wandb:
-        wandb.config.update({
-            "n_model_params": 
-            sum(p.numel() for p in model.parameters())
-        })
+        n_params = sum(p.numel() for p in model.parameters())
+        wandb.config.update({"n_model_params": n_params})
     # Tuning options. Batch autoscaling is unsupported; LR tuning logs the
     # suggested value and then exits.
     if args.auto_scale_batch_size:

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -325,8 +325,9 @@ def main() -> None:
     model = get_model_from_argparse_args(args, datamodule)
     # Logs number of model parameters.
     if args.log_wandb:
-        n_params = sum(p.numel() for p in model.parameters())
-        wandb.config["n_model_params"] = n_params
+        wandb.config["n_model_params"] = sum(
+            p.numel() for p in model.parameters()
+        )
     # Tuning options. Batch autoscaling is unsupported; LR tuning logs the
     # suggested value and then exits.
     if args.auto_scale_batch_size:

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -323,6 +323,12 @@ def main() -> None:
     trainer = get_trainer_from_argparse_args(args)
     datamodule = get_datamodule_from_argparse_args(args)
     model = get_model_from_argparse_args(args, datamodule)
+    # Logs number of model parameters.
+    if args.log_wandb:
+        wandb.config.update({
+            "n_model_params": 
+            sum(p.numel() for p in model.parameters())
+        })
     # Tuning options. Batch autoscaling is unsupported; LR tuning logs the
     # suggested value and then exits.
     if args.auto_scale_batch_size:


### PR DESCRIPTION
Adds number of model parameters to W&B log. 

Note that PTL logs this to stdout by default, but it is convenient to have a column in W&B for this, so that we do not need to retrieve and parse all stdout logs for large analysis.