### PR TITLE
specifying 'seperate features' for hard_attention

### DIFF
--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -129,6 +129,7 @@ def get_datamodule_from_argparse_args(
         data.DataModule.
     """
     separate_features = args.features_col != 0 and args.arch in [
+        "hard_attention_lstm",
         "pointer_generator_lstm",
         "pointer_generator_transformer",
         "transducer",


### PR DESCRIPTION
Hot fix for `hard_attention`

I was a silly billy and forgot to add `hard_attention` models to class of models that separates features in dataloading.

Fixes: https://github.com/CUNY-CL/yoyodyne/issues/194