### PR TITLE
adding expert to hp ignore due to pickeling issue

### DIFF
--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -153,7 +153,7 @@ class BaseEncoderDecoder(pl.LightningModule):
         self.decoder = self.get_decoder()
         # Saves hyperparameters for PL checkpointing.
         self.save_hyperparameters(
-            ignore=["source_encoder", "decoder", "features_encoder"]
+            ignore=["source_encoder", "decoder", "expert", "features_encoder"]
         )
         # Logs the module names.
         util.log_info(f"Model: {self.name}")


### PR DESCRIPTION
Fixes: https://github.com/CUNY-CL/yoyodyne/issues/192

TQDM in the transducer's expert module doesn't pickle currently. So when doing multi-gpu training, pytorch gets annoyed. Since it's not really needed beyond training, I'm dropping it from the model.

Note, when running prediction with the model, the lack of the hyperparameter means a new expert will have to be created. This is dumb, so need to add a dummy class to the transducer model to avoid this. This portion I'm leaving in draft atm.