### PR TITLE
Pad tensor after eos

### DIFF
--- a/yoyodyne/evaluators.py
+++ b/yoyodyne/evaluators.py
@@ -152,37 +152,11 @@ class AccuracyEvaluator(Evaluator):
         Returns:
             torch.Tensor: finalized predictions.
         """
-        # Not necessary if batch size is 1.
-        if predictions.size(0) == 1:
-            return predictions
-        for i, prediction in enumerate(predictions):
-            # Gets first instance of EOS.
-            eos = (prediction == end_idx).nonzero(as_tuple=False)
-            if len(eos) > 0 and eos[0].item() < len(prediction):
-                # If an EOS was decoded and it is not the last one in the
-                # sequence.
-                eos = eos[0]
-            else:
-                # Leaves predictions[i] alone.
-                continue
-            # Hack in case the first prediction is EOS. In this case
-            # torch.split will result in an error, so we change these 0's to
-            # 1's, which will make the entire sequence EOS as intended.
-            eos[eos == 0] = 1
-            symbols, *_ = torch.split(prediction, eos)
-            # Replaces everything after with PAD, to replace erroneous decoding
-            # While waiting on the entire batch to finish.
-            pads = (
-                torch.ones(
-                    len(prediction) - len(symbols), device=symbols.device
-                )
-                * pad_idx
-            )
-            pads[0] = end_idx
-            # Makes an in-place update to an inference tensor.
-            with torch.inference_mode():
-                predictions[i] = torch.cat((symbols, pads))
-        return predictions
+        return util.pad_tensor_after_eos(
+            predictions,
+            end_idx,
+            pad_idx,
+        )
 
     def finalize_golds(
         self,
@@ -242,8 +216,20 @@ class SEREvaluator(Evaluator):
         self,
         tensor: torch.Tensor,
         end_idx: int,
-        pad_idx: int,
-    ) -> torch.Tensor:
+    ) -> List[torch.Tensor]:
+        """Finalizes each tensor.
+
+        Truncates at EOS for each prediction and returns a List of predictions.
+        This does basically the same as util.pad_after_eos, but does
+        not actually pad since we do not need to return a well-formed tensor.
+
+        Args:
+            tensor (torch.Tensor): _description_
+            end_idx (int): _description_
+
+        Returns:
+            List[torch.Tensor]: _description_
+        """
         # Not necessary if batch size is 1.
         if tensor.size(0) == 1:
             return [tensor]
@@ -271,8 +257,9 @@ class SEREvaluator(Evaluator):
         self,
         predictions: torch.Tensor,
         end_idx: int,
-        pad_idx: int,
-    ) -> torch.Tensor:
+        *args,
+        **kwargs,
+    ) -> List[torch.Tensor]:
         """Finalizes predictions.
 
         Args:
@@ -281,17 +268,28 @@ class SEREvaluator(Evaluator):
             pad_idx (int).
 
         Returns:
-            torch.Tensor: finalized predictions.
+            List[torch.Tensor]: finalized predictions.
         """
-        return self._finalize_tensor(predictions, end_idx, pad_idx)
+        return self._finalize_tensor(predictions, end_idx)
 
     def finalize_golds(
         self,
         golds: torch.Tensor,
         end_idx: int,
-        pad_idx: int,
-    ) -> torch.Tensor:
-        return self._finalize_tensor(golds, end_idx, pad_idx)
+        *args,
+        **kwargs,
+    ) -> List[torch.Tensor]:
+        """Finalizes predictions.
+
+        Args:
+            predictions (torch.Tensor): prediction tensor.
+            end_idx (int).
+            pad_idx (int).
+
+        Returns:
+            List[torch.Tensor]: finalized predictions.
+        """
+        return self._finalize_tensor(golds, end_idx)
 
     @property
     def name(self) -> str:

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -100,9 +100,9 @@ def predict(
     loader = datamodule.predict_dataloader()
     with open(output, "w") as sink:
         for batch in trainer.predict(model, loader):
-            # batch = model.evaluator.finalize_predictions(
-            #     batch, datamodule.index.end_idx, datamodule.index.pad_idx
-            # )
+            batch = util.pad_tensor_after_eos(
+                batch, datamodule.index.end_idx, datamodule.index.pad_idx
+            )
             for prediction in loader.dataset.decode_target(batch):
                 print(prediction, file=sink)
 

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -100,9 +100,9 @@ def predict(
     loader = datamodule.predict_dataloader()
     with open(output, "w") as sink:
         for batch in trainer.predict(model, loader):
-            batch = model.evaluator.finalize_predictions(
-                batch, datamodule.index.end_idx, datamodule.index.pad_idx
-            )
+            # batch = model.evaluator.finalize_predictions(
+            #     batch, datamodule.index.end_idx, datamodule.index.pad_idx
+            # )
             for prediction in loader.dataset.decode_target(batch):
                 print(prediction, file=sink)
 

--- a/yoyodyne/util.py
+++ b/yoyodyne/util.py
@@ -3,6 +3,8 @@
 import argparse
 import sys
 
+import torch
+
 from typing import Any, Optional
 
 
@@ -20,6 +22,61 @@ class UniqueAddAction(argparse.Action):
         option_string: Optional[str] = None,
     ) -> None:
         getattr(namespace, self.dest).add(values)
+
+
+# Tensor manipulation
+
+
+def pad_tensor_after_eos(
+    predictions: torch.Tensor,
+    end_idx: int,
+    pad_idx: int,
+) -> torch.Tensor:
+    """Replaces everything after an EOS token with PADs.
+
+    Cuts off tensors at the first end_idx, and replaces the rest of the
+    predictions with pad_idx, as these can be erroneously decoded while the
+    rest of the batch is finishing decoding.
+
+    Args:
+        predictions (torch.Tensor): prediction tensor.
+        end_idx (int).
+        pad_idx (int).
+
+    Returns:
+        torch.Tensor: finalized predictions.
+    """
+    # Not necessary if batch size is 1.
+    if predictions.size(0) == 1:
+        return predictions
+    for i, prediction in enumerate(predictions):
+        # Gets first instance of EOS.
+        eos = (prediction == end_idx).nonzero(as_tuple=False)
+        if len(eos) > 0 and eos[0].item() < len(prediction):
+            # If an EOS was decoded and it is not the last one in the
+            # sequence.
+            eos = eos[0]
+        else:
+            # Leaves predictions[i] alone.
+            continue
+        # Hack in case the first prediction is EOS. In this case
+        # torch.split will result in an error, so we change these 0's to
+        # 1's, which will make the entire sequence EOS as intended.
+        eos[eos == 0] = 1
+        symbols, *_ = torch.split(prediction, eos)
+        # Replaces everything after with PAD, to replace erroneous decoding
+        # While waiting on the entire batch to finish.
+        pads = (
+            torch.ones(
+                len(prediction) - len(symbols), device=symbols.device
+            )
+            * pad_idx
+        )
+        pads[0] = end_idx
+        # Makes an in-place update to an inference tensor.
+        with torch.inference_mode():
+            predictions[i] = torch.cat((symbols, pads))
+    return predictions
 
 
 # Logging.

--- a/yoyodyne/util.py
+++ b/yoyodyne/util.py
@@ -67,9 +67,7 @@ def pad_tensor_after_eos(
         # Replaces everything after with PAD, to replace erroneous decoding
         # While waiting on the entire batch to finish.
         pads = (
-            torch.ones(
-                len(prediction) - len(symbols), device=symbols.device
-            )
+            torch.ones(len(prediction) - len(symbols), device=symbols.device)
             * pad_idx
         )
         pads[0] = end_idx


### PR DESCRIPTION
In #184 I seem to have forgotten to test `predict.py`. It attempts to get a handle on the old `evaluator` in order to `finalize_predictions`, but now we have multiple evaluators and don't know which one to use.

Instead, this generalizes the notion of replacing everything after EOS in a tensor with a PAD and puts it in util.py. We can now use that for prediction in case the model predicts random chars after EOS. I also made minor clarifications to `evaluators.py`, where we sometimes `finalize_*` without replacing with PADs, as they are unnecessary if we aren't keeping a tensor as in the SER case.

I will need to test the evaluators beforemerging, but was hoping to get eyes on this for design or naming issues.