### PR TITLE
Autosizing modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,9 +320,9 @@ update](https://lightning.ai/docs/pytorch/stable/common/optimization.html#id3):
 
 The `--find_batch_size` flag enables [automatically computation of
 the batch size](https://lightning.ai/docs/pytorch/stable/advanced/training_tricks.html#batch-size-finder).
-With `--find_batch_size max`, it simply uses the largest batch size.
-With `--find_batch_size opt`, it finds the maximum, and then interprets it
-as follows:
+With `--find_batch_size max`, it simply uses the largest batch size, ignoring
+`--batch_size`. With `--find_batch_size opt`, it finds the maximum batch size,
+and then interprets it as follows:
 
 -   If the maximum batch size is greater than `--batch_size`, then
     `--batch_size` is used as the batch size.

--- a/README.md
+++ b/README.md
@@ -318,19 +318,18 @@ update](https://lightning.ai/docs/pytorch/stable/common/optimization.html#id3):
 
     yoyodyne-train --batch_size 1024 --accumulate_grad_batches 4 ...
 
-With the `--find_batch_size` flag enabled, Yoyodyne will [automatically compute
-the maximum batch
-size](https://lightning.ai/docs/pytorch/stable/advanced/training_tricks.html#batch-size-finder).
-The exact beahvior of this operation is controlled by the flags
-`--find_batch_size_mode`, `--find_batch_size_steps_per_trial`, and
-`--find_batch_size_max_trials`. The result is interpreted as follows:
+The `--find_batch_size` flag enables [automatically computation of
+the batch size](https://lightning.ai/docs/pytorch/stable/advanced/training_tricks.html#batch-size-finder).
+With `--find_batch_size max`, it simply uses the largest batch size.
+With `--find_batch_size opt`, it finds the maximum, and then interprets it
+as follows:
 
 -   If the maximum batch size is greater than `--batch_size`, then
-    `--batch_size` is used as the effective batch size.
--   If the maximum batch size is less than `--batch_size`, it determines the
-    optimal gradient accumulation solution, picking the largest batch size and
-    the smallest number of gradient accumulation steps whose product is
-    `--batch_size` and thus optimally saturating the accelerator.
+    `--batch_size` is used as the batch size.
+-   However, if the maximum batch size is less than `--batch_size`, it solves 
+    for the optimal gradient accumulation trick and uses the largest batch size
+    and the smallest number of gradient accumulation steps whose product is
+    `--batch_size`, thus optimally saturating the accelerator.
 
 If one wishes to solve for these quantities without actually training, pass
 `--find_batch_size` and `--max_epochs 0`. This will halt after computing and

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ update](https://lightning.ai/docs/pytorch/stable/common/optimization.html#id3):
 
 The `--find_batch_size` flag enables [automatically computation of
 the batch size](https://lightning.ai/docs/pytorch/stable/advanced/training_tricks.html#batch-size-finder).
-With `--find_batch_size max`, it simply uses the largest batch size, ignoring
+With `--find_batch_size max`, it simply uses the maximum batch size, ignoring
 `--batch_size`. With `--find_batch_size opt`, it finds the maximum batch size,
 and then interprets it as follows:
 
@@ -329,11 +329,11 @@ and then interprets it as follows:
 -   However, if the maximum batch size is less than `--batch_size`, it solves 
     for the optimal gradient accumulation trick and uses the largest batch size
     and the smallest number of gradient accumulation steps whose product is
-    `--batch_size`, thus optimally saturating the accelerator.
+    `--batch_size`.
 
 If one wishes to solve for these quantities without actually training, pass
-`--find_batch_size` and `--max_epochs 0`. This will halt after computing and
-logging the solution.
+`--find_batch_size opt` and `--max_epochs 0`. This will halt after computing
+and logging the solution.
 
 ### Hyperparameter tuning
 

--- a/examples/wandb_sweeps/train_wandb_sweep.py
+++ b/examples/wandb_sweeps/train_wandb_sweep.py
@@ -10,7 +10,7 @@ import pytorch_lightning as pl
 import torch
 import wandb
 
-from yoyodyne import train, util
+from yoyodyne import sizing, train, util
 
 
 warnings.filterwarnings("ignore", ".*is a wandb run already in progress.*")
@@ -39,7 +39,16 @@ def train_sweep(args: argparse.Namespace) -> None:
     trainer = train.get_trainer_from_argparse_args(args)
     datamodule = train.get_datamodule_from_argparse_args(args)
     model = train.get_model_from_argparse_args(args, datamodule)
-    # Trains and logs the best checkpoint.
+    if args.find_batch_size:
+        sizing.find_batch_size(
+            args.find_batch_size,
+            trainer,
+            model,
+            datamodule,
+            mode=args.find_batch_size_mode,
+            steps_per_trial=args.find_batch_size_steps_per_trial,
+            max_trials=args.find_batch_size_max_trials,
+        )
     best_checkpoint = train.train(trainer, model, datamodule, args.train_from)
     util.log_info(f"Best checkpoint: {best_checkpoint}")
     # Explicitly deallocates model and clears the CUDA cache, based on the

--- a/yoyodyne/defaults.py
+++ b/yoyodyne/defaults.py
@@ -35,8 +35,7 @@ MAX_SOURCE_LENGTH = 128
 MAX_TARGET_LENGTH = 128
 EVAL_METRICS = set()
 
-# Tuning arguments.
-FIND_BATCH_SIZE = False
+# Tuning arguments. These just mirror the defaults in the tuner library.
 FIND_BATCH_SIZE_MODE = "power"
 FIND_BATCH_SIZE_STEPS_PER_TRIAL = 3
 FIND_BATCH_SIZE_MAX_TRIALS = 25

--- a/yoyodyne/sizing.py
+++ b/yoyodyne/sizing.py
@@ -145,7 +145,7 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         "--find_batch_size",
         choices=["max", "opt"],
         help="Automatically find either the `max`(imum) or the `opt`(imal; "
-        "i.e., maximally saturated) batch size. Default: not enabled.",
+        "i.e., via gradient accumulation) batch size. Default: not enabled.",
     )
     parser.add_argument(
         "--find_batch_size_mode",

--- a/yoyodyne/sizing.py
+++ b/yoyodyne/sizing.py
@@ -128,7 +128,7 @@ def find_batch_size(
     else:
         raise Error(f"Unknown batch sizing method: {method}")
     util.log_info(f"Using batch size: {datamodule.batch_size}")
-    if trainer.accumulate_grad_batches:
+    if trainer.accumulate_grad_batches != 1:
         util.log_info(
             "Using gradient accumulation steps: "
             f"{trainer.accumulate_grad_batches}"

--- a/yoyodyne/sizing.py
+++ b/yoyodyne/sizing.py
@@ -117,16 +117,16 @@ def find_batch_size(
         steps_per_trial=steps_per_trial,
     )
     util.log_info(f"Max batch size: {max_batch_size}")
-    if find_batch_size == "max":
+    if method == "max":
         datamodule.batch_size = max_batch_size
-    elif find_batch_size == "opt":
+    elif method == "opt":
         steps, batch_size = _optimal_batch_size(
             datamodule.batch_size, max_batch_size
         )
         datamodule.batch_size = batch_size
         trainer.accumulate_grad_batches = steps
     else:
-        raise Error(f"Unknown find_batch_size method: {find_batch_size}")
+        raise Error(f"Unknown batch sizing method: {method}")
     util.log_info(f"Using batch size: {datamodule.batch_size}")
     if trainer.accumulate_grad_batches:
         util.log_info(


### PR DESCRIPTION
In this follow-up to #194, I make it so that the batch size finder has two modes:

* `opt`imal mode is the same as before: it uses the gradient accumulation trick if necessary
* `max` mode just finds the max batch size and uses it, ignoring `--batch_size`

I theorize the latter would be really useful for when you have reason to believe the model does well with large batches (this might be all models?) and rather than tuning it, want to tune the other hyperparameters instead.

I am testing this with a fancy Bayesian sweep [here](https://wandb.ai/hyperparam-sensitivity/pol-max_batch-hard_monotonic_lstm?nw=nwuserkylebgorman) (the link may not be accessible to just anyone). 