### PR TITLE
Adds a script to retrieve hyperparameters

### DIFF
--- a/examples/wandb_sweeps/README.md
+++ b/examples/wandb_sweeps/README.md
@@ -3,9 +3,9 @@
 This directory contains example scripts for running a hyperparameter sweep with
 [Weights & Biases](https://wandb.ai/site).
 
--   [`config.yaml`](config.yaml) contains just one possible hyparparameter
-    grid, designed for random search over an attentive LSTM; edit that file
-    directly to build a hyperparameter grid appropriate for your problem.
+-   [`config.yaml`](config.yaml) contains just one possible hyparparameter grid,
+    designed for random search over an attentive LSTM; edit that file directly
+    to build a hyperparameter grid appropriate for your problem.
 -   Consider also running Bayesian search (`method: bayes`) instead of random
     search; see
     [here](https://docs.wandb.ai/guides/sweeps/define-sweep-configuration#configuration-keys)
@@ -42,3 +42,9 @@ Then, one can retrieve the results as follows:
 
 3.  Click on the downward arrow link, select "CSV Export", then click "Save as
     CSV".
+
+Alternatively, one can use [`best_hyperparameters.py`](best_hyperparamaters.py)
+to retrieve the hyperparameters of the best run, formatted as Bash-style flags:
+
+    ./best_hyperparameters.py --entity "${ENTITY}" --project "${PROJECT}" \
+         --sweep_id "${SWEEP_ID}"

--- a/examples/wandb_sweeps/best_hyperparameters.py
+++ b/examples/wandb_sweeps/best_hyperparameters.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""Retrieve hyperparameters from a W&B sweep."""
+
+import argparse
+import logging
+
+from yoyodyne import defaults
+import wandb
+
+
+# Expand as needed.
+FLAGS_TO_IGNORE = frozenset(["eval_metrics", "local_run_dir"])
+
+
+def main(args: argparse.Namespace) -> None:
+    api = wandb.Api()
+    sweep = api.sweep(f"{args.entity}/{args.project}/{args.sweep_id}")
+    best_run = sweep.best_run()
+    logging.info("Best run URL: %s", best_run.url)
+    # Sorting for stability.
+    for key, value in sorted(best_run.config.items()):
+        # Exclusions:
+        #
+        # * Explicitly ignored flags
+        # * Keys with "/" is for redundant parameters in the scheduler.
+        # * Key/value pairs that are defaults can be omitted.
+        # * Keys ending in "_cls", "_idx", and "vocab_size" are set
+        #   automatically.
+        # * None values are defaults definitionally.
+        if key in FLAGS_TO_IGNORE:
+            continue
+        if "/" in key:
+            continue
+        key_upper = key.upper()
+        if hasattr(defaults, key_upper):
+            if getattr(defaults, key_upper) == value:
+                continue
+        if (
+            key.endswith("_cls")
+            or key.endswith("_idx")
+            or key.endswith("vocab_size")
+        ):
+            continue
+        if value is None:
+            continue
+        # Print like a list of flags...
+        print(f"    --{key} {value} \\")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format="%(levelname)s: %(message)s", level="INFO")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--entity", required=True, help="The entity scope for the project."
+    )
+    parser.add_argument(
+        "--project", required=True, help="The project of the sweep."
+    )
+    parser.add_argument("--sweep_id", required=True, help="ID for the sweep.")
+    main(parser.parse_args())


### PR DESCRIPTION
This script usees the W&B API to find the best run and then retrieve its hyperparameters. Some hacks are used to suppress redundant hyperparameters (or things that are not really hyperparameters) and to print them out as flags so that this could be used like:

        yoyodyne-train ... $(./best_hyperparameters ...)