### PR TITLE
Cleanup of some flag help strings

### DIFF
--- a/yoyodyne/evaluators.py
+++ b/yoyodyne/evaluators.py
@@ -331,5 +331,5 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         action=util.UniqueAddAction,
         choices=_eval_factory.keys(),
         default=defaults.EVAL_METRICS,
-        help="Additional metrics to compute. Default: none.",
+        help="Additional metrics to compute.",
     )

--- a/yoyodyne/models/__init__.py
+++ b/yoyodyne/models/__init__.py
@@ -87,7 +87,8 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         default=defaults.TIE_EMBEDDINGS,
         help="Shares embeddings for the source and target vocabularies. "
-        "Always enable this with pointer-generator architectures.",
+        "Always enable this with pointer-generator and transducer "
+        "architectures. Default: enabled.",
     )
     parser.add_argument(
         "--no_tie_embeddings",

--- a/yoyodyne/models/lstm.py
+++ b/yoyodyne/models/lstm.py
@@ -342,8 +342,8 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
             "--bidirectional",
             action="store_true",
             default=defaults.BIDIRECTIONAL,
-            help="Uses a bidirectional encoder "
-            "(LSTM-backed architectures only. Default: %(default)s.",
+            help="Uses a bidirectional encoder (LSTM-backed architectures "
+            "only. Default: enabled.",
         )
         parser.add_argument(
             "--no_bidirectional",

--- a/yoyodyne/sizing.py
+++ b/yoyodyne/sizing.py
@@ -128,12 +128,12 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         "--find_batch_size",
         choices=["max", "opt"],
         help="Automatically find either the `max`(imum) or the `opt`(imal; "
-        "i.e., via gradient accumulation) batch size. Default: not enabled.",
+        "i.e., via gradient accumulation) batch size.",
     )
     parser.add_argument(
         "--find_batch_size_steps_per_trial",
         type=int,
         default=defaults.FIND_BATCH_SIZE_STEPS_PER_TRIAL,
         help="Number of steps to run with a given batch size. "
-        "Default: %(default)s",
+        "Default: %(default)s.",
     )

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -317,7 +317,8 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         help="Path to input validation data TSV.",
     )
     parser.add_argument(
-        "--train_from", help="Path to ckpt checkpoint to resume training from."
+        "--train_from",
+        help="Path to checkpoint used to resume training.",
     )
     # Other training arguments.
     parser.add_argument(
@@ -346,8 +347,8 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         choices=["accuracy", "loss", "ser"],
         default=defaults.PATIENCE_METRIC,
         help="Stops early when validation `accuracy` does not increase or "
-        "when validation `loss` or `ser` does not decrease for `--patience` "
-        "epochs. Default: %(default)s.",
+        "when validation `loss` or `ser` does not decrease. "
+        "Default: %(default)s.",
     )
     parser.add_argument("--seed", type=int, help="Random seed.")
     parser.add_argument(

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -317,9 +317,7 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         help="Path to input validation data TSV.",
     )
     parser.add_argument(
-        "--train_from",
-        help="Path to ckpt checkpoint to resume training from. "
-        "Default: not enabled.",
+        "--train_from", help="Path to ckpt checkpoint to resume training from."
     )
     # Other training arguments.
     parser.add_argument(
@@ -341,23 +339,23 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         "--patience",
         type=int,
         help="Number of epochs with no progress (according to "
-        "`--patience_metric`) before triggering early stopping. "
-        "Default: not enabled.",
+        "`--patience_metric`) before triggering early stopping.",
     )
     parser.add_argument(
         "--patience_metric",
         choices=["accuracy", "loss", "ser"],
         default=defaults.PATIENCE_METRIC,
-        help="Stops early when validation `accuracy` stops increasing or "
-        "when validation `loss` or `ser` stops decreasing. "
-        "Default: %(default)s.",
+        help="Stops early when validation `accuracy` does not increase or "
+        "when validation `loss` or `ser` does not decrease for `--patience` "
+        "epochs. Default: %(default)s.",
     )
     parser.add_argument("--seed", type=int, help="Random seed.")
     parser.add_argument(
         "--log_wandb",
         action="store_true",
         default=defaults.LOG_WANDB,
-        help="Use Weights & Biases logging (log-in required). Default: True.",
+        help="Use Weights & Biases logging (log-in required). "
+        "Default: not enabled.",
     )
     parser.add_argument(
         "--no_log_wandb",


### PR DESCRIPTION
* If something has a null default, don't list a default at all ("not enabled" isn't always precise enough).
* For a boolean flag (e.g., --foo/--no_foo) defaulting to true, give its default as "enabled".
* For a boolean flag defaulting to false, give its default as "not enabled".
* Mention that transducer architectures go wtih tied embeddings.
* Mention that patience_metric goes with patience.