### PR TITLE
Enables verbosity for early stopping/patience

### DIFF
--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -81,6 +81,7 @@ def _get_callbacks(
                 mode=metric.mode,
                 monitor=metric.monitor,
                 patience=patience,
+                min_delta=1e-4,
                 verbose=True,
             )
         )

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -81,6 +81,7 @@ def _get_callbacks(
                 mode=metric.mode,
                 monitor=metric.monitor,
                 patience=patience,
+                verbose=True,
             )
         )
     # Checkpointing callback. Ensure that this is the last checkpoint,


### PR DESCRIPTION
This one-line change logs that early stopping has kicked in. Without it there's no logging information about early stopping at all. There are other places we could in theory increase verbosity and I may issue PRs for those so we can see if we like them. 

Here is an example of what is logged. It's a bit verbose as you might expect:

```
Epoch 38: 100%|██████████| 3/3 [00:01<00:00,  2.44it/s, loss=2.71, v_num=pzub, val_accuracy=0.000, val_loss=3.020]Metric val_loss improved by 0.008 >= min_delta = 0.0. New best score: 3.021
Epoch 44: 100%|█████████| 3/3 [00:01<00:00,  2.54it/s, loss=2.51, v_num=pzub, val_accuracy=0.0084, val_loss=3.000]Metric val_loss improved by 0.022 >= min_delta = 0.0. New best score: 2.999
Epoch 45: 100%|█████████| 3/3 [00:01<00:00,  2.66it/s, loss=2.48, v_num=pzub, val_accuracy=0.0084, val_loss=3.000]Metric val_loss improved by 0.003 >= min_delta = 0.0. New best score: 2.996
Epoch 50: 100%|██████████| 3/3 [00:01<00:00,  2.46it/s, loss=2.3, v_num=pzub, val_accuracy=0.0168, val_loss=2.990]Metric val_loss improved by 0.010 >= min_delta = 0.0. New best score: 2.987
```

It may be too much but I thought I'd propose it all the same.

I have also taken the liberty of adding a non-zero "delta"/threshold for best; 1e-4, which is the same one used for reduce-on-plateau scheduling and seems quite small in the context of patience.