### PR TITLE
Adds support for additional Python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       command-run:
         type: string
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.12
     steps:
       - checkout
       - run:
@@ -65,4 +65,4 @@ workflows:
             - twine
           matrix:
             parameters:
-              python-version: ["3.9", "3.10"]
+              python-version: ["3.9", "3.10", "3.11", "3.12"]

--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ yourself.
 
 ### Local installation
 
-Yoyodyne currently supports Python 3.9 and 3.10.
-[#60](https://github.com/CUNY-CL/yoyodyne/issues/60) is a known blocker to
-Python \> 3.10 support.
+Yoyodyne currently supports Python 3.9 through 3.12.
 
 First install dependencies:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = ["examples*"]
 
 [project]
 name = "yoyodyne"
-version = "0.2.11"
+version = "0.2.12"
 description = "Small-vocabulary neural sequence-to-sequence models"
 readme = "README.md"
 requires-python = ">= 3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ name = "yoyodyne"
 version = "0.2.11"
 description = "Small-vocabulary neural sequence-to-sequence models"
 readme = "README.md"
-requires-python = ">= 3.9, < 3.11"
+requires-python = ">= 3.9"
 license = { text = "Apache 2.0" }
 authors = [
     {name = "Adam Wiemerslage"},
@@ -37,6 +37,8 @@ dependencies = [
 classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
 Enables support for Python > 3.10.

At some earlier point we were stuck on PyTorch <2, and there was no support for Python 3.10 or later. #173 freed us from this restriction, but left in the restriction to PyTorch-Lightning <2. However, we were pinned on Python <= 3.10 by PyTorch, not PyTorch-Lightning, so we can now add support for additional Pythons.

Python 3.12 is the actively developed branch; Python 3.8-3.11 are are on long-term (i.e., security-fix) support; Python 3.8 is just about to go out of date and Python 3.13 is approaching prerelease: https://devguide.python.org/versions/. So this adds support for all supported Python versions (except 3.8, which was already old when we started this project and which we never supported in the first place).

I have updated the patch-level since this is worth putting on PyPI; I also have enabled testing on additional versions.

This is closely related to, but does not close, #60.