### PR TITLE
Moves embedding initialization to its own module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       command-run:
         type: string
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.12
     steps:
       - checkout
       - run:
@@ -65,4 +65,4 @@ workflows:
             - twine
           matrix:
             parameters:
-              python-version: ["3.9", "3.10"]
+              python-version: ["3.9", "3.10", "3.11", "3.12"]

--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ yourself.
 
 ### Local installation
 
-Yoyodyne currently supports Python 3.9 and 3.10.
-[#60](https://github.com/CUNY-CL/yoyodyne/issues/60) is a known blocker to
-Python \> 3.10 support.
+Yoyodyne currently supports Python 3.9 through 3.12.
 
 First install dependencies:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ exclude = ["examples*"]
 
 [project]
 name = "yoyodyne"
-version = "0.2.11"
+version = "0.2.12"
 description = "Small-vocabulary neural sequence-to-sequence models"
 readme = "README.md"
-requires-python = ">= 3.9, < 3.11"
+requires-python = ">= 3.9"
 license = { text = "Apache 2.0" }
 authors = [
     {name = "Adam Wiemerslage"},
@@ -37,6 +37,8 @@ dependencies = [
 classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "License :: OSI Approved :: Apache Software License",

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -172,54 +172,6 @@ class BaseEncoderDecoder(pl.LightningModule):
         util.log_info(f"Decoder: {self.decoder.name}")
 
     @staticmethod
-    def _xavier_embedding_initialization(
-        num_embeddings: int, embedding_size: int, pad_idx: int
-    ) -> nn.Embedding:
-        """Initializes the embeddings layer using Xavier initialization.
-
-        The pad embeddings are also zeroed out.
-
-        Args:
-            num_embeddings (int): number of embeddings.
-            embedding_size (int): dimension of embeddings.
-            pad_idx (int): index of pad symbol.
-
-        Returns:
-            nn.Embedding: embedding layer.
-        """
-        embedding_layer = nn.Embedding(num_embeddings, embedding_size)
-        # Xavier initialization.
-        nn.init.normal_(
-            embedding_layer.weight, mean=0, std=embedding_size**-0.5
-        )
-        # Zeroes out pad embeddings.
-        if pad_idx is not None:
-            nn.init.constant_(embedding_layer.weight[pad_idx], 0.0)
-        return embedding_layer
-
-    @staticmethod
-    def _normal_embedding_initialization(
-        num_embeddings: int, embedding_size: int, pad_idx: int
-    ) -> nn.Embedding:
-        """Initializes the embeddings layer from a normal distribution.
-
-        The pad embeddings are also zeroed out.
-
-        Args:
-            num_embeddings (int): number of embeddings.
-            embedding_size (int): dimension of embeddings.
-            pad_idx (int): index of pad symbol.
-
-        Returns:
-            nn.Embedding: embedding layer.
-        """
-        embedding_layer = nn.Embedding(num_embeddings, embedding_size)
-        # Zeroes out pad embeddings.
-        if pad_idx is not None:
-            nn.init.constant_(embedding_layer.weight[pad_idx], 0.0)
-        return embedding_layer
-
-    @staticmethod
     def init_embeddings(
         num_embed: int, embed_size: int, pad_idx: int
     ) -> nn.Embedding:

--- a/yoyodyne/models/embeddings.py
+++ b/yoyodyne/models/embeddings.py
@@ -1,0 +1,49 @@
+"""Embedding initialization functions."""
+
+from torch import nn
+
+
+def xavier_embedding(
+    num_embeddings: int, embedding_size: int, pad_idx: int
+) -> nn.Embedding:
+    """Initializes the embeddings layer using Xavier initialization.
+
+    The pad embeddings are also zeroed out.
+
+    Args:
+        num_embeddings (int): number of embeddings.
+        embedding_size (int): dimension of embeddings.
+        pad_idx (int): index of pad symbol.
+
+    Returns:
+        nn.Embedding: embedding layer.
+    """
+    embedding_layer = nn.Embedding(num_embeddings, embedding_size)
+    # Xavier initialization.
+    nn.init.normal_(embedding_layer.weight, mean=0, std=embedding_size**-0.5)
+    # Zeroes out pad embeddings.
+    if pad_idx is not None:
+        nn.init.constant_(embedding_layer.weight[pad_idx], 0.0)
+    return embedding_layer
+
+
+def normal_embedding(
+    num_embeddings: int, embedding_size: int, pad_idx: int
+) -> nn.Embedding:
+    """Initializes the embeddings layer from a normal distribution.
+
+    The pad embeddings are also zeroed out.
+
+    Args:
+        num_embeddings (int): number of embeddings.
+        embedding_size (int): dimension of embeddings.
+        pad_idx (int): index of pad symbol.
+
+    Returns:
+        nn.Embedding: embedding layer.
+    """
+    embedding_layer = nn.Embedding(num_embeddings, embedding_size)
+    # Zeroes out pad embeddings.
+    if pad_idx is not None:
+        nn.init.constant_(embedding_layer.weight[pad_idx], 0.0)
+    return embedding_layer

--- a/yoyodyne/models/embeddings.py
+++ b/yoyodyne/models/embeddings.py
@@ -3,6 +3,28 @@
 from torch import nn
 
 
+def normal_embedding(
+    num_embeddings: int, embedding_size: int, pad_idx: int
+) -> nn.Embedding:
+    """Initializes the embeddings layer from a normal distribution.
+
+    The pad embeddings are also zeroed out.
+
+    Args:
+        num_embeddings (int): number of embeddings.
+        embedding_size (int): dimension of embeddings.
+        pad_idx (int): index of pad symbol.
+
+    Returns:
+        nn.Embedding: embedding layer.
+    """
+    embedding_layer = nn.Embedding(num_embeddings, embedding_size)
+    # Zeroes out pad embeddings.
+    if pad_idx is not None:
+        nn.init.constant_(embedding_layer.weight[pad_idx], 0.0)
+    return embedding_layer
+
+
 def xavier_embedding(
     num_embeddings: int, embedding_size: int, pad_idx: int
 ) -> nn.Embedding:
@@ -21,28 +43,6 @@ def xavier_embedding(
     embedding_layer = nn.Embedding(num_embeddings, embedding_size)
     # Xavier initialization.
     nn.init.normal_(embedding_layer.weight, mean=0, std=embedding_size**-0.5)
-    # Zeroes out pad embeddings.
-    if pad_idx is not None:
-        nn.init.constant_(embedding_layer.weight[pad_idx], 0.0)
-    return embedding_layer
-
-
-def normal_embedding(
-    num_embeddings: int, embedding_size: int, pad_idx: int
-) -> nn.Embedding:
-    """Initializes the embeddings layer from a normal distribution.
-
-    The pad embeddings are also zeroed out.
-
-    Args:
-        num_embeddings (int): number of embeddings.
-        embedding_size (int): dimension of embeddings.
-        pad_idx (int): index of pad symbol.
-
-    Returns:
-        nn.Embedding: embedding layer.
-    """
-    embedding_layer = nn.Embedding(num_embeddings, embedding_size)
     # Zeroes out pad embeddings.
     if pad_idx is not None:
         nn.init.constant_(embedding_layer.weight[pad_idx], 0.0)

--- a/yoyodyne/models/lstm.py
+++ b/yoyodyne/models/lstm.py
@@ -8,7 +8,7 @@ import torch
 from torch import nn
 
 from .. import data, defaults
-from . import base, modules
+from . import base, embeddings, modules
 
 
 class LSTMEncoderDecoder(base.BaseEncoderDecoder):
@@ -52,7 +52,7 @@ class LSTMEncoderDecoder(base.BaseEncoderDecoder):
         Returns:
             nn.Embedding: embedding layer.
         """
-        return self._normal_embedding_initialization(
+        return embeddings.normal_embedding(
             num_embeddings, embedding_size, pad_idx
         )
 

--- a/yoyodyne/models/modules/transformer.py
+++ b/yoyodyne/models/modules/transformer.py
@@ -228,8 +228,8 @@ class FeatureInvariantTransformerEncoder(TransformerEncoder):
         # Uses Xavier initialization.
         self.type_embedding = embeddings.xavier_initialization(
             2,
-            embedding_size,
-            pad_idx,
+            self.embedding_size,
+            self.pad_idx,
         )
 
     def embed(self, symbols: torch.Tensor) -> torch.Tensor:

--- a/yoyodyne/models/modules/transformer.py
+++ b/yoyodyne/models/modules/transformer.py
@@ -226,7 +226,7 @@ class FeatureInvariantTransformerEncoder(TransformerEncoder):
         # Distinguishes features vs. character.
         self.features_vocab_size = features_vocab_size
         # Uses Xavier initialization.
-        self.type_embedding = embeddings.xavier_initialization(
+        self.type_embedding = embeddings.xavier_embedding(
             2,
             self.embedding_size,
             self.pad_idx,

--- a/yoyodyne/models/modules/transformer.py
+++ b/yoyodyne/models/modules/transformer.py
@@ -7,6 +7,7 @@ import torch
 from torch import nn
 
 from ... import data
+from .. import embeddings
 from . import base
 
 
@@ -224,8 +225,11 @@ class FeatureInvariantTransformerEncoder(TransformerEncoder):
         super().__init__(*args, **kwargs)
         # Distinguishes features vs. character.
         self.features_vocab_size = features_vocab_size
-        self.type_embedding = self.init_embeddings(
-            2, self.embedding_size, self.pad_idx
+        # Uses Xavier initialization.
+        self.type_embedding = embeddings.xavier_initialization(
+            2,
+            embedding_size,
+            pad_idx,
         )
 
     def embed(self, symbols: torch.Tensor) -> torch.Tensor:

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -7,7 +7,7 @@ import torch
 from torch import nn
 
 from .. import data, defaults
-from . import base, embedding, modules
+from . import base, embeddings, modules
 
 
 class TransformerEncoderDecoder(base.BaseEncoderDecoder):

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -7,7 +7,7 @@ import torch
 from torch import nn
 
 from .. import data, defaults
-from . import base, modules
+from . import base, embedding, modules
 
 
 class TransformerEncoderDecoder(base.BaseEncoderDecoder):
@@ -53,7 +53,7 @@ class TransformerEncoderDecoder(base.BaseEncoderDecoder):
         Returns:
             nn.Embedding: embedding layer.
         """
-        return self._xavier_embedding_initialization(
+        return embeddings.xavier_embedding(
             num_embeddings, embedding_size, pad_idx
         )
 

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -81,6 +81,8 @@ def _get_callbacks(
                 mode=metric.mode,
                 monitor=metric.monitor,
                 patience=patience,
+                min_delta=1e-4,
+                verbose=True,
             )
         )
     # Checkpointing callback. Ensure that this is the last checkpoint,


### PR DESCRIPTION
These were previously stored as static methods in the base model. But they are also needed at the module level, so we separate them. This should fix the break in the feature invariant transformer reported in #215. (Closes #215.)