### PR TITLE
Fixes bug with optional features encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ additional flags. Supported values for `--arch` are:
     `--source_attention_heads`; default: `4`).
 
 The user can override the default encoder architectures. One can override the
-source encoder using the `--source_encoder` flag:
+source encoder using the `--source_encoder_arch` flag:
 
 -   `feature_invariant_transformer`: This is a variant of the transformer
     encoder used with features; it concatenates source and features and uses a
@@ -231,7 +231,7 @@ source encoder using the `--source_encoder` flag:
 -   `transformer`: This is a transformer encoder.
 
 When using features, the user can also specify a non-default features encoder
-using the `--features_encoder` flag (`linear`, `lstm`, `transformer`).
+using the `--features_encoder_arch` flag (`linear`, `lstm`, `transformer`).
 
 For all models, the user may also wish to specify:
 

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -210,17 +210,26 @@ def get_model_from_argparse_args(
         else None
     )
     scheduler_kwargs = schedulers.get_scheduler_kwargs_from_argparse_args(args)
-    separate_features = datamodule.has_features and args.arch in [
-        "hard_attention_lstm",
-        "pointer_generator_lstm",
-        "pointer_generator_transformer",
-        "transducer",
-    ]
+    # We use a separate features encoder if the datamodule has features, and either:
+    # - a specific features encoder module is requested (in which case we use
+    #   the requested module), or
+    # - the model requires that we use a separate features encoder (in which
+    #   case we use the same module as the source encoder).
     features_encoder_cls = (
         models.modules.get_encoder_cls(
             encoder_arch=args.features_encoder_arch, model_arch=args.arch
         )
-        if separate_features and args.features_encoder_arch
+        if datamodule.has_features
+        and (
+            args.features_encoder_arch
+            or args.arch
+            in [
+                "hard_attention_lstm",
+                "pointer_generator_lstm",
+                "pointer_generator_transformer",
+                "transducer",
+            ]
+        )
         else None
     )
     features_vocab_size = (

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -210,11 +210,13 @@ def get_model_from_argparse_args(
         else None
     )
     scheduler_kwargs = schedulers.get_scheduler_kwargs_from_argparse_args(args)
-    # We use a separate features encoder if the datamodule has features, and either:
+    # We use a separate features encoder if the datamodule has features, and
+    # either:
     # - a specific features encoder module is requested (in which case we use
     #   the requested module), or
-    # - the model requires that we use a separate features encoder (in which
-    #   case we use the same module as the source encoder).
+    # - no specific features encoder module is requested, but the model
+    #   requires that we use a separate features encoder (in which case we use
+    #   the same module as the source encoder).
     features_encoder_cls = (
         models.modules.get_encoder_cls(
             encoder_arch=args.features_encoder_arch, model_arch=args.arch


### PR DESCRIPTION
The logic in `train.py` was to use a separate features encoder module if:

- features are present in the datamodule
- the model requires features to be separate from source (e.g., pointer-generators)
- and a separate features encoder module is requested.

This is incorrect; the logic should read:

- features are present in the datamodule, and
      - a separate features encoder module is requested, or
      - the model requires features to be separate from source.

In the case where the model requires it but a specific features encoder module is not specified, we use the same module as the source encoder; e.g., a pointer-generator LSTM will have an LSTM source encoder and an LSTM features encoder.

The README was also out of date: the flags are `--source_encoder_arch` and `--features_encoder_arch` (was missing the `_arch` part).