### PR TITLE
Separates vocabularies for logging

### DIFF
--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -150,15 +150,19 @@ class Index:
 
     @property
     def source_vocab_size(self) -> int:
-        return len(special.SPECIAL) + len(self.source_vocabulary)
+        if self.tie_embeddings:
+            return self.vocab_size
+        else:
+            return len(self.SPECIAL) + len(self.source_vocabulary)
 
     @property
     def target_vocab_size(self) -> int:
-        return (
-            len(special.SPECIAL) + len(self.target_vocabulary)
-            if self.target_vocabulary
-            else 0
-        )
+        if self.tie_embeddings:
+            return self.vocab_size
+        elif self.target_vocabulary:
+            return len(special.SPECIAL) + len(self.target_vocabulary)
+        else:
+            return 0
 
     @property
     def features_vocab_size(self) -> int:

--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -2,7 +2,7 @@
 
 import os
 import pickle
-from typing import Dict, Iterable, Optional, Set
+from typing import Dict, Iterable, List, Optional, Set
 
 from .. import defaults, special
 
@@ -43,7 +43,7 @@ class Index:
         self.tie_embeddings = tie_embeddings
         # We store vocabularies separately for logging purposes.
         self.source_vocabulary = sorted(source_vocabulary)
-        self.target_vocabulary = sorted(target_vocabalary)
+        self.target_vocabulary = sorted(target_vocabulary)
         if self.tie_embeddings:
             # Vocabulary is the union of source and target.
             vocabulary = sorted(
@@ -52,7 +52,8 @@ class Index:
         else:
             # Vocabulary consists of target symbols followed by source symbols.
             vocabulary = sorted(target_vocabulary) + sorted(source_vocabulary)
-        # FeatureInvariantTransformer assumes that features_vocabulary is at the end of the vocabulary.
+        # FeatureInvariantTransformer assumes that features_vocabulary is at
+        # the end of the vocabulary.
         if features_vocabulary is not None:
             self.features_vocabulary = sorted(features_vocabulary)
             vocabulary.extend(self.features_vocabulary)

--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -14,8 +14,12 @@ class Error(Exception):
 class Index:
     """Maintains the index over the vocabularies.
 
-    For consistency, one is recommended to lexicographically sort the
-    vocabularies ahead of time."""
+    Args:
+        source_vocabulary (Iterable[str]).
+        features_vocabulary (Iterable[str], optional).
+        target_vocabulary (Iterable[str], optional).
+        tie_embeddings: (bool).
+    """
 
     source_vocabulary: List[str]
     target_vocabulary: List[str]
@@ -31,14 +35,6 @@ class Index:
         target_vocabulary: Optional[Iterable[str]] = None,
         tie_embeddings: bool = defaults.TIE_EMBEDDINGS,
     ):
-        """Initializes the index.
-
-        Args:
-            source_vocabulary (List[str]).
-            features_vocabulary (List[str], optional).
-            target_vocabulary (List[str], optional).
-            tie_embeddings: (bool).
-        """
         super().__init__()
         self.tie_embeddings = tie_embeddings
         # We store vocabularies separately for logging purposes.
@@ -47,7 +43,7 @@ class Index:
         if self.tie_embeddings:
             # Vocabulary is the union of source and target.
             vocabulary = sorted(
-                frozenset(source_vocabulary) | frozenset(target_vocabulary)
+                frozenset(source_vocabulary + target_vocabulary)
             )
         else:
             # Vocabulary consists of target symbols followed by source symbols.
@@ -154,11 +150,15 @@ class Index:
 
     @property
     def source_vocab_size(self) -> int:
-        return len(self.source_vocabulary)
+        return len(special.SPECIAL) + len(self.source_vocabulary)
 
     @property
     def target_vocab_size(self) -> int:
-        return len(self.target_vocabulary) if self.target_vocabulary else 0
+        return (
+            len(special.SPECIAL) + len(self.target_vocabulary)
+            if self.target_vocabulary
+            else 0
+        )
 
     @property
     def features_vocab_size(self) -> int:

--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -2,7 +2,7 @@
 
 import os
 import pickle
-from typing import Dict, List, Optional, Set
+from typing import Dict, Iterable, Optional, Set
 
 from .. import defaults, special
 
@@ -17,15 +17,18 @@ class Index:
     For consistency, one is recommended to lexicographically sort the
     vocabularies ahead of time."""
 
-    index2symbol: List[str]
-    symbol2index: Dict[str, int]
+    source_vocabulary: List[str]
+    target_vocabulary: List[str]
+    features_vocabulary = Optional[List[str]]
+    _index2symbol: List[str]
+    _symbol2index: Dict[str, int]
 
     def __init__(
         self,
         *,
-        source_vocabulary: List[str],
-        features_vocabulary: Optional[List[str]] = None,
-        target_vocabulary: Optional[List[str]] = None,
+        source_vocabulary: Iterable[str],
+        features_vocabulary: Optional[Iterable[str]] = None,
+        target_vocabulary: Optional[Iterable[str]] = None,
         tie_embeddings: bool = defaults.TIE_EMBEDDINGS,
     ):
         """Initializes the index.
@@ -38,27 +41,23 @@ class Index:
         """
         super().__init__()
         self.tie_embeddings = tie_embeddings
-        # We store all separate vocabularies for logging purposes.
-        # If embeddings are tied, so are the vocab items.
-        # Then, the source and target vocabularies are the union.
+        # We store vocabularies separately for logging purposes.
+        self.source_vocabulary = sorted(source_vocabulary)
+        self.target_vocabulary = sorted(target_vocabalary)
         if self.tie_embeddings:
-            vocabulary = list(
-                sorted(set(source_vocabulary) | set(target_vocabulary))
+            # Vocabulary is the union of source and target.
+            vocabulary = sorted(
+                frozenset(source_vocabulary) | frozenset(target_vocabulary)
             )
-            self.source_vocabulary = special.SPECIAL + vocabulary
-            self.target_vocabulary = special.SPECIAL + vocabulary
         else:
-            # If not tie_embeddings, then the target vocabulary must come
-            # first so that output predictions correctly index our
-            # vocabulary and embeddiings matrix.
+            # Vocabulary consists of target symbols followed by source symbols.
             vocabulary = sorted(target_vocabulary) + sorted(source_vocabulary)
-            self.source_vocabulary = special.SPECIAL + source_vocabulary
-            self.target_vocabulary = special.SPECIAL + target_vocabulary
-        # FeatureInvariantTransformer assumes that features_vocabulary is at
-        # the end of the list.
-        if features_vocabulary:
-            vocabulary.extend(sorted(features_vocabulary))
-        self.features_vocabulary = features_vocabulary
+        # FeatureInvariantTransformer assumes that features_vocabulary is at the end of the vocabulary.
+        if features_vocabulary is not None:
+            self.features_vocabulary = sorted(features_vocabulary)
+            vocabulary.extend(self.features_vocabulary)
+        else:
+            self.features_vocabulary = None
         # Keeps special.SPECIAL first to maintain overlap with features.
         self._index2symbol = special.SPECIAL + vocabulary
         self._symbol2index = {c: i for i, c in enumerate(self._index2symbol)}


### PR DESCRIPTION
Current logic is such that source and target vocabularies (which are stored solely for logging and debugging purposes) are unioned together if `--tied_embeddings`. However, the purpose of these logging statements has nothing to do with embedding tying, so we modify them so that they are not combined except when building the actual vocabulary. We also remove the special symbols from the logging since they serve no purpose there.

Before (example with mostly-disjoint vocabulary...):
```
Source vocabulary: '<UNK>', '<P>', '<S>', '<E>', '1', '2', '5', '8', '9', '@', 'E', 'G', 'N', 'O', 'R', 'S', 'Z', 'a', 'b', 'd', 'e', 'f', 'g', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '§', '°', 'ø', 'ŋ', 'œ', 'œ̃', 'ɑ', 'ɑ̃', 'ɔ', 'ɔ̃', 'ə', 'ɛ', 'ɛː', 'ɛ̃', 'ɡ', 'ɥ', 'ɲ', 'ʁ', 'ʃ', 'ʒ', '‿'
Target vocabulary: '<UNK>', '<P>', '<S>', '<E>', '1', '2', '5', '8', '9', '@', 'E', 'G', 'N', 'O', 'R', 'S', 'Z', 'a', 'b', 'd', 'e', 'f', 'g', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '§', '°', 'ø', 'ŋ', 'œ', 'œ̃', 'ɑ', 'ɑ̃', 'ɔ', 'ɔ̃', 'ə', 'ɛ', 'ɛː', 'ɛ̃', 'ɡ', 'ɥ', 'ɲ', 'ʁ', 'ʃ', 'ʒ', '‿'
```

After (ditto; note I am hiding the special symbols):
```
Source vocabulary: 'a', 'b', 'd', 'e', 'f', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'r', 's', 't', 'u', 'v', 'w', 'y', 'z', 'ø', 'ŋ', 'œ', 'œ̃', 'ɑ', 'ɑ̃', 'ɔ', 'ɔ̃', 'ə', 'ɛ', 'ɛː', 'ɛ̃', 'ɡ', 'ɥ', 'ɲ', 'ʁ', 'ʃ', 'ʒ', '‿'
Target vocabulary: '1', '2', '5', '8', '9', '@', 'E', 'G', 'N', 'O', 'R', 'S', 'Z', 'a', 'b', 'd', 'e', 'f', 'g', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '§', '°'
```

Closes #212.