### PR TITLE
Disables `norm_first` in the transformer encoder

### DIFF
--- a/yoyodyne/models/modules/transformer.py
+++ b/yoyodyne/models/modules/transformer.py
@@ -189,7 +189,7 @@ class TransformerEncoder(TransformerModule):
             nhead=self.source_attention_heads,
             dropout=self.dropout,
             activation="relu",
-            norm_first=True,
+            norm_first=False,
             batch_first=True,
         )
         return nn.TransformerEncoder(


### PR DESCRIPTION
This allows us to use the experimental, but supposedly faster, nested tensor API:

https://pytorch.org/docs/stable/nested.html

As the documentation indicates, this apparently is particularly helpful with padding. 

Closes #214. Mutually exclusive with #225.