### PR TITLE
Disables the use of nested tensors

### DIFF
--- a/yoyodyne/models/modules/transformer.py
+++ b/yoyodyne/models/modules/transformer.py
@@ -196,6 +196,7 @@ class TransformerEncoder(TransformerModule):
             encoder_layer=encoder_layer,
             num_layers=self.layers,
             norm=nn.LayerNorm(self.embedding_size),
+            enable_nested_tensor=False,
         )
 
     @property

--- a/yoyodyne/models/modules/transformer.py
+++ b/yoyodyne/models/modules/transformer.py
@@ -189,6 +189,8 @@ class TransformerEncoder(TransformerModule):
             nhead=self.source_attention_heads,
             dropout=self.dropout,
             activation="relu",
+            # TODO(#224): Consider disabling this and enabling
+            # `enable_nested_tensor` below.
             norm_first=True,
             batch_first=True,
         )
@@ -196,6 +198,8 @@ class TransformerEncoder(TransformerModule):
             encoder_layer=encoder_layer,
             num_layers=self.layers,
             norm=nn.LayerNorm(self.embedding_size),
+            # TODO(#224): Consider disabling `norm_first` and enabling this
+            # feature.
             enable_nested_tensor=False,
         )
 


### PR DESCRIPTION
We can just silence the warning by agreeing not to use the nested tensors backend.

Closes #214. Mutually exclusive with #224.