### PR TITLE
Clears the cache after an OOM during sweeps

### DIFF
--- a/examples/wandb_sweeps/train_wandb_sweep.py
+++ b/examples/wandb_sweeps/train_wandb_sweep.py
@@ -32,10 +32,10 @@ def train_sweep(args: argparse.Namespace) -> None:
         setattr(args, key, value)
     try:
         train.train(args)  # Ignoring return value.
-    except RuntimeError:
+    except RuntimeError as error:
         # TODO: consider specializing this further if a solution to
         # https://github.com/pytorch/pytorch/issues/48365 is accepted.
-        pass
+        util.log_info(f"Runtime error: {error!s}")
     finally:
         # Clears the CUDA cache.
         torch.cuda.empty_cache()

--- a/examples/wandb_sweeps/train_wandb_sweep.py
+++ b/examples/wandb_sweeps/train_wandb_sweep.py
@@ -10,14 +10,10 @@ import pytorch_lightning as pl
 import torch
 import wandb
 
-from yoyodyne import sizing, train, util
+from yoyodyne import train, util
 
 
 warnings.filterwarnings("ignore", ".*is a wandb run already in progress.*")
-
-
-class Error(Exception):
-    pass
 
 
 def train_sweep(args: argparse.Namespace) -> None:
@@ -35,26 +31,14 @@ def train_sweep(args: argparse.Namespace) -> None:
         if key in args:
             util.log_info(f"Overriding CLI argument: {key}")
         setattr(args, key, value)
-    pl.seed_everything(args.seed)
-    trainer = train.get_trainer_from_argparse_args(args)
-    datamodule = train.get_datamodule_from_argparse_args(args)
-    model = train.get_model_from_argparse_args(args, datamodule)
-    if args.find_batch_size:
-        sizing.find_batch_size(
-            args.find_batch_size,
-            trainer,
-            model,
-            datamodule,
-            steps_per_trial=args.find_batch_size_steps_per_trial,
-        )
-    best_checkpoint = train.train(trainer, model, datamodule, args.train_from)
-    util.log_info(f"Best checkpoint: {best_checkpoint}")
-    # Explicitly deallocates model and clears the CUDA cache, based on the
-    # following suggestion:
-    #
-    #     https://github.com/wandb/wandb/issues/1247#issuecomment-1457737657
-    del model
-    torch.cuda.empty_cache()
+    try:
+        train.train(args)  # Ignoring return value.
+    except RunTimeError:
+        # This is usually an OOM.
+        pass
+    finally:
+        # Clears the CUDA cache.
+        torch.cuda.empty_cache()
 
 
 def main() -> None:

--- a/examples/wandb_sweeps/train_wandb_sweep.py
+++ b/examples/wandb_sweeps/train_wandb_sweep.py
@@ -6,7 +6,6 @@ import functools
 import traceback
 import warnings
 
-import pytorch_lightning as pl
 import torch
 import wandb
 
@@ -33,7 +32,7 @@ def train_sweep(args: argparse.Namespace) -> None:
         setattr(args, key, value)
     try:
         train.train(args)  # Ignoring return value.
-    except RunTimeError:
+    except RuntimeError:
         # TODO: consider specializing this further if a solution to
         # https://github.com/pytorch/pytorch/issues/48365 is accepted.
         pass

--- a/examples/wandb_sweeps/train_wandb_sweep.py
+++ b/examples/wandb_sweeps/train_wandb_sweep.py
@@ -34,7 +34,8 @@ def train_sweep(args: argparse.Namespace) -> None:
     try:
         train.train(args)  # Ignoring return value.
     except RunTimeError:
-        # This is usually an OOM.
+        # TODO: consider specializing this further if a solution to
+        # https://github.com/pytorch/pytorch/issues/48365 is accepted.
         pass
     finally:
         # Clears the CUDA cache.

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -340,9 +340,7 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         help="Path to input validation data TSV.",
     )
     parser.add_argument(
-        "--train_from",
-        help="Path to ckpt checkpoint to resume training from. "
-        "Default: not enabled.",
+        "--train_from", help="Path to checkpoint used to resume training."
     )
     # Other training arguments.
     parser.add_argument(
@@ -364,15 +362,14 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         "--patience",
         type=int,
         help="Number of epochs with no progress (according to "
-        "`--patience_metric`) before triggering early stopping. "
-        "Default: not enabled.",
+        "`--patience_metric`) before triggering early stopping. ",
     )
     parser.add_argument(
         "--patience_metric",
         choices=["accuracy", "loss", "ser"],
         default=defaults.PATIENCE_METRIC,
-        help="Stops early when validation `accuracy` stops increasing or "
-        "when validation `loss` or `ser` stops decreasing. "
+        help="Stops early when validation `accuracy` does not increase or "
+        "when validation `loss` or `ser` does not decrease. "
         "Default: %(default)s.",
     )
     parser.add_argument("--seed", type=int, help="Random seed.")
@@ -380,7 +377,8 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         "--log_wandb",
         action="store_true",
         default=defaults.LOG_WANDB,
-        help="Use Weights & Biases logging (log-in required). Default: True.",
+        help="Use Weights & Biases logging (log-in required). "
+        "Default: not enabled.",
     )
     parser.add_argument(
         "--no_log_wandb",

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -192,8 +192,8 @@ def get_model_from_argparse_args(
         and not args.tie_embeddings
     ):
         raise Error(
-            f"--tie_embeddings set to {args.tie_embeddings}, but "
-            f"--arch {args.arch} requires it to be enabled."
+            f"--tie_embeddings disabled, but --arch {args.arch} requires "
+            "it to be enabled"
         )
     source_encoder_cls = models.modules.get_encoder_cls(
         encoder_arch=args.source_encoder_arch, model_arch=args.arch
@@ -278,30 +278,40 @@ def get_model_from_argparse_args(
     )
 
 
-def train(
-    trainer: pl.Trainer,
-    model: models.BaseEncoderDecoder,
-    datamodule: data.DataModule,
-    train_from: Optional[str] = None,
-) -> str:
+def train(args: argparse.Namespace) -> str:
     """Trains the model.
 
     Args:
-         trainer (pl.Trainer).
-         model (models.BaseEncoderDecoder).
-         datamodule (data.DataModule).
-         train_from (str, optional): if specified, starts training from this
-            checkpoint.
+        args (argparse.Namespace).
 
     Returns:
         str: path to best checkpoint.
     """
-    trainer.fit(model, datamodule, ckpt_path=train_from)
+    if args.log_wandb:
+        wandb.init()
+    pl.seed_everything(args.seed)
+    trainer = get_trainer_from_argparse_args(args)
+    datamodule = get_datamodule_from_argparse_args(args)
+    model = get_model_from_argparse_args(args, datamodule)
+    if args.log_wandb:
+        # Logs number of model parameters for W&B.
+        wandb.config["n_model_params"] = sum(
+            p.numel() for p in model.parameters()
+        )
+    if args.find_batch_size:
+        sizing.find_batch_size(
+            args.find_batch_size,
+            trainer,
+            datamodule,
+            steps_per_trial=args.find_batch_size_steps_per_trial,
+        )
+    trainer.fit(model, datamodule, ckpt_path=args.train_from)
     # The API assumes that the last callback is the checkpointing one, and
     # _get_callbacks must enforce this.
-    ckp_callback = trainer.callbacks[-1]
-    assert type(ckp_callback) is callbacks.ModelCheckpoint
-    return ckp_callback.best_model_path
+    checkpoint_callback = trainer.callbacks[-1]
+    assert checkpoint_callback.best_model_path
+    util.log_info(f"Best checkpoint: {checkpoint_callback.best_model_path}")
+    return checkpoint_callback.best_model_path
 
 
 def add_argparse_args(parser: argparse.ArgumentParser) -> None:
@@ -331,7 +341,8 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--train_from",
-        help="Path to checkpoint used to resume training.",
+        help="Path to ckpt checkpoint to resume training from. "
+        "Default: not enabled.",
     )
     # Other training arguments.
     parser.add_argument(
@@ -353,14 +364,15 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         "--patience",
         type=int,
         help="Number of epochs with no progress (according to "
-        "`--patience_metric`) before triggering early stopping.",
+        "`--patience_metric`) before triggering early stopping. "
+        "Default: not enabled.",
     )
     parser.add_argument(
         "--patience_metric",
         choices=["accuracy", "loss", "ser"],
         default=defaults.PATIENCE_METRIC,
-        help="Stops early when validation `accuracy` does not increase or "
-        "when validation `loss` or `ser` does not decrease. "
+        help="Stops early when validation `accuracy` stops increasing or "
+        "when validation `loss` or `ser` stops decreasing. "
         "Default: %(default)s.",
     )
     parser.add_argument("--seed", type=int, help="Random seed.")
@@ -368,8 +380,7 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         "--log_wandb",
         action="store_true",
         default=defaults.LOG_WANDB,
-        help="Use Weights & Biases logging (log-in required). "
-        "Default: not enabled.",
+        help="Use Weights & Biases logging (log-in required). Default: True.",
     )
     parser.add_argument(
         "--no_log_wandb",
@@ -414,27 +425,7 @@ def main() -> None:
     add_argparse_args(parser)
     args = parser.parse_args()
     util.log_arguments(args)
-    if args.log_wandb:
-        wandb.init()
-    pl.seed_everything(args.seed)
-    trainer = get_trainer_from_argparse_args(args)
-    datamodule = get_datamodule_from_argparse_args(args)
-    model = get_model_from_argparse_args(args, datamodule)
-    if args.log_wandb:
-        # Logs number of model parameters for W&B.
-        wandb.config["n_model_params"] = sum(
-            p.numel() for p in model.parameters()
-        )
-    if args.find_batch_size:
-        sizing.find_batch_size(
-            args.find_batch_size,
-            trainer,
-            model,
-            datamodule,
-            steps_per_trial=args.find_batch_size_steps_per_trial,
-        )
-    best_checkpoint = train(trainer, model, datamodule, args.train_from)
-    util.log_info(f"Best checkpoint: {best_checkpoint}")
+    train(args)
 
 
 if __name__ == "__main__":

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -362,7 +362,7 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         "--patience",
         type=int,
         help="Number of epochs with no progress (according to "
-        "`--patience_metric`) before triggering early stopping. ",
+        "`--patience_metric`) before triggering early stopping.",
     )
     parser.add_argument(
         "--patience_metric",


### PR DESCRIPTION
As reported in #227, memory is not freed after an OOM during the sweep, meaning that, usually, all subsequent sweeps also fail. We solve this by:

1. Cleaning up the `train.train` API with a more friendly endpoint. This has the desirable effect that there is no longer any need to keep `train_wandb_sweep.py` "up to date" with trainer interface: it just takes `args` and handles the rest.
2. Wrapping the call to `train.train` in a `try`/`except` with a `finally:` block that clears the CUDA cache.

Closes #227.

Sample test:

```
# This has deliberately huge batch sizes---kbg.
$ cat config/bad_config.yaml
method: random
metric:
  name: val_accuracy
  goal: maximize
parameters:
  # Constants.
  arch:
    value: attentive_lstm
  # Hyperparameters.
  encoder_layers:
    values: [1, 2]
  embedding_size:
    distribution: q_uniform
    q: 16
    min: 16
    max: 512
  hidden_size:
    distribution: q_uniform
    q: 64
    min: 64
    max: 1024
  dropout:
    distribution: uniform
    min: 0
    max: 0.5
  label_smoothing:
    distribution: uniform
    min: 0.0
    max: 0.2
  batch_size:
    distribution: q_uniform
    q: 1024
    min: 1024
    max: 4096
  beta1:
    distribution: uniform
    min: 0.8
    max: 0.999
  beta2:
    distribution: uniform
    min: 0.98
    max: 0.999
  learning_rate:
    distribution: log_uniform_values
    min: 0.00001
    max: 0.01
  scheduler:
    values: [null, reduceonplateau, warmupinvsqrt]
  reduceonplateau_factor:
    distribution: uniform
    min: 0.1
    max: 0.9
  reduceonplateau_patience:
    distribution: q_uniform
    q: 1
    min: 1
    max: 5
  min_learning_rate:
    distribution: log_uniform_values
    min: 0.000001
    max: 0.001
  warmup_steps:
    distribution: q_uniform
    q: 50
    min: 50
    max: 5000
$ export ENTITY=cuny-cl
$ export PROJECT=OOM
$ wandb sweep --entity "${ENTITY}" --project "${PROJECT}" config/b
ad_config.yaml
wandb: Creating sweep from: config/bad_config.yaml
wandb: Creating sweep with ID: vjt25un4
wandb: View sweep at: https://wandb.ai/cuny-cl/OOM/sweeps/vjt25un4
wandb: Run sweep agent with: wandb agent cuny-cl/OOM/vjt25un4
$ ../../yoyodyne-wrap/examples/wandb_sweeps/./train_wandb_sweep.py --entity "${ENTITY}" --project "${PROJECT}" --sweep_id vjt25un4 --count 50 --experiment "${PROJECT}" --model_dir models --train ../tsv/eng/polyg2p-train.tsv --val ../tsv/eng/polyg2p-dev.tsv --source_sep " " --target_sep " " --features_col 3 --features_encoder linear --accelerator gpu --gradient_clip_val 3 --max_epochs 100 --max_time 01:00:00:00 --patience 10 --seed 1985
...
```