### PR TITLE
Consistency fix for factory lookups

### DIFF
--- a/yoyodyne/__init__.py
+++ b/yoyodyne/__init__.py
@@ -1,3 +1,5 @@
+"""Yoyodyne: small-vocabulary sequence-to-sequence generation."""
+
 import warnings
 
 # Silences irrelevant warnings; these are more like "Did you know?"s.

--- a/yoyodyne/data/collators.py
+++ b/yoyodyne/data/collators.py
@@ -10,7 +10,7 @@ from .. import defaults, util
 from . import batches, datasets
 
 
-class LengthError(Exception):
+class Error(Exception):
     pass
 
 
@@ -33,10 +33,10 @@ class Collator:
             padded_length (int): The length of the the padded tensor.
 
         Raises:
-            LengthError.
+            Error.
         """
         if padded_length > self.max_source_length:
-            raise LengthError(
+            raise Error(
                 f"The length of a source sample ({padded_length}) is greater "
                 f"than the `--max_source_length` specified "
                 f"({self.max_source_length})"

--- a/yoyodyne/data/datamodules.py
+++ b/yoyodyne/data/datamodules.py
@@ -110,6 +110,7 @@ class DataModule(pl.LightningDataModule):
 
     @staticmethod
     def pprint(vocabulary: Iterable) -> str:
+        """Prints the vocabulary for debugging adn logging purposes."""
         return ", ".join(f"{symbol!r}" for symbol in vocabulary)
 
     def log_vocabularies(self) -> None:

--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -130,8 +130,6 @@ class Index:
         with open(path, "wb") as sink:
             pickle.dump(vars(self), sink)
 
-    # Properties.
-
     @property
     def symbols(self) -> List[str]:
         return list(self._symbol2index.keys())

--- a/yoyodyne/data/tsv.py
+++ b/yoyodyne/data/tsv.py
@@ -12,8 +12,6 @@ from .. import defaults
 
 
 class Error(Exception):
-    """Module-specific exception."""
-
     pass
 
 

--- a/yoyodyne/evaluators.py
+++ b/yoyodyne/evaluators.py
@@ -296,7 +296,7 @@ class SEREvaluator(Evaluator):
         return "ser"
 
 
-_eval_factory = {
+_eval_fac = {
     "accuracy": AccuracyEvaluator,
     "ser": SEREvaluator,
 }
@@ -308,16 +308,18 @@ def get_evaluator(eval_metric: str) -> Evaluator:
     Args:
         eval_metric (str).
 
-    Raises:
-        Error.
-
     Returns:
         Evaluator.
+
+    Raises:
+        NotImplementedError: Evaluation metric not found.
     """
     try:
-        return _eval_factory[eval_metric]
+        return _eval_fac[eval_metric]
     except KeyError:
-        raise Error(f"No evaluation metric {eval_metric}")
+        raise NotImplementedError(
+            f"Evaluation metric not found: {eval_metric}"
+        )
 
 
 def add_argparse_args(parser: argparse.ArgumentParser) -> None:
@@ -329,7 +331,7 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--eval_metric",
         action=util.UniqueAddAction,
-        choices=_eval_factory.keys(),
+        choices=_eval_fac.keys(),
         default=defaults.EVAL_METRICS,
         help="Additional metrics to compute.",
     )

--- a/yoyodyne/models/__init__.py
+++ b/yoyodyne/models/__init__.py
@@ -1,4 +1,4 @@
-"""Model classes and lookup function."""
+"""Yoyodyne models."""
 
 import argparse
 
@@ -14,6 +14,17 @@ from .transducer import TransducerEncoderDecoder
 from .transformer import TransformerEncoderDecoder
 
 
+_model_fac = {
+    "attentive_lstm": AttentiveLSTMEncoderDecoder,
+    "hard_attention_lstm": HardAttentionLSTM,
+    "lstm": LSTMEncoderDecoder,
+    "pointer_generator_lstm": PointerGeneratorLSTMEncoderDecoder,
+    "pointer_generator_transformer": PointerGeneratorTransformerEncoderDecoder,  # noqa: 501
+    "transducer": TransducerEncoderDecoder,
+    "transformer": TransformerEncoderDecoder,
+}
+
+
 def get_model_cls(arch: str) -> BaseEncoderDecoder:
     """Model factory.
 
@@ -22,22 +33,13 @@ def get_model_cls(arch: str) -> BaseEncoderDecoder:
         has_features (bool).
 
     Raises:
-        NotImplementedError.
+        NotImplementedError: Architecture not found.
 
     Returns:
         BaseEncoderDecoder.
     """
-    model_fac = {
-        "attentive_lstm": AttentiveLSTMEncoderDecoder,
-        "hard_attention_lstm": HardAttentionLSTM,
-        "lstm": LSTMEncoderDecoder,
-        "pointer_generator_lstm": PointerGeneratorLSTMEncoderDecoder,
-        "pointer_generator_transformer": PointerGeneratorTransformerEncoderDecoder,  # noqa: 501
-        "transducer": TransducerEncoderDecoder,
-        "transformer": TransformerEncoderDecoder,
-    }
     try:
-        return model_fac[arch]
+        return _model_fac[arch]
     except KeyError:
         raise NotImplementedError(f"Architecture {arch} not found")
 
@@ -49,9 +51,6 @@ def get_model_cls_from_argparse_args(
 
     Args:
         args (argparse.Namespace).
-
-    Raises:
-        NotImplementedError.
 
     Returns:
         BaseEncoderDecoder.
@@ -70,15 +69,7 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
     """
     parser.add_argument(
         "--arch",
-        choices=[
-            "attentive_lstm",
-            "hard_attention_lstm",
-            "lstm",
-            "pointer_generator_lstm",
-            "pointer_generator_transformer",
-            "transducer",
-            "transformer",
-        ],
+        choices=_model_fac.keys(),
         default="attentive_lstm",
         help="Model architecture. Default: %(default)s.",
     )

--- a/yoyodyne/schedulers.py
+++ b/yoyodyne/schedulers.py
@@ -158,16 +158,12 @@ class ReduceOnPlateau(optim.lr_scheduler.ReduceLROnPlateau):
 def add_argparse_args(parser: argparse.ArgumentParser) -> None:
     """Adds shared configuration options to the argument parser.
 
-    These are only needed at training time.
+    These are only needed at training time. Note that the actual scheduler
+    arg is specified in models/base.py.
 
     Args:
         parser (argparse.ArgumentParser).
     """
-    parser.add_argument(
-        "--scheduler",
-        choices=["warmupinvsqrt", "lineardecay", "reduceonplateau"],
-        help="Learning rate scheduler.",
-    )
     parser.add_argument(
         "--warmup_steps",
         type=int,


### PR DESCRIPTION
This makes it so that we use a consistent style for factories:

* `_foo_fac` defined out of line
* `_foo_fac.keys()` used to define the `--foo` `choices=` field in the argparser
* raises `NotImplementedError("[Thing] not found: {foo}")`