### PR TITLE
Moves from `pytorch-lighting` to `lightning` package.

### DIFF
--- a/examples/wandb_sweeps/best_hyperparameters.py
+++ b/examples/wandb_sweeps/best_hyperparameters.py
@@ -4,9 +4,9 @@
 import argparse
 import logging
 
-from yoyodyne import defaults
 import wandb
 
+from yoyodyne import defaults
 
 # Expand as needed.
 FLAGS_TO_IGNORE = frozenset(["eval_metrics", "local_run_dir"])

--- a/examples/wandb_sweeps/train_wandb_sweep.py
+++ b/examples/wandb_sweeps/train_wandb_sweep.py
@@ -11,7 +11,6 @@ import wandb
 
 from yoyodyne import train, util
 
-
 warnings.filterwarnings("ignore", ".*is a wandb run already in progress.*")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,9 @@ keywords = [
 ]
 dependencies = [
     "maxwell >= 0.2.4",
-    # TODO: allow >= 2.0.0 once we we migrate to pytorch-lightning >= 2.0.0".
+    # TODO: allow >= 2.0.0 once we we migrate to lightning >= 2.0.0".
     "numpy >= 1.26.0, < 2.0.0", 
-    "pytorch-lightning >= 1.7.0, < 2.0.0",
+    "lightning >= 1.7.0, < 2.0.0",
     "torch >= 2.4.0",
     "wandb >= 0.17.5",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 black>=24.4.2
 build>=1.2.1
 flake8>=7.1.0
+lightning>=1.7.0,<2.0.0
 maxwell>=0.2.4
 numpy>=1.26.0,<2.0.0
 pandas>=2.2.2
 pytest>=8.3.2
-pytorch-lightning>=1.7.0,<2.0.0
 scipy>=1.13.1
 setuptools>=72.1.0
 torch>=2.4.0

--- a/yoyodyne/data/datamodules.py
+++ b/yoyodyne/data/datamodules.py
@@ -2,14 +2,14 @@
 
 from typing import Iterable, Optional, Set
 
-import pytorch_lightning as pl
+import lightning
 from torch.utils import data
 
 from .. import defaults, util
 from . import collators, datasets, indexes, tsv
 
 
-class DataModule(pl.LightningDataModule):
+class DataModule(lightning.LightningDataModule):
     """Parses, indexes, collates and loads data.
 
     The batch size tuner is permitted to mutate the `batch_size` argument.

--- a/yoyodyne/models/__init__.py
+++ b/yoyodyne/models/__init__.py
@@ -2,8 +2,8 @@
 
 import argparse
 
-from .base import BaseEncoderDecoder
 from .. import defaults
+from .base import BaseEncoderDecoder
 from .hard_attention import HardAttentionLSTM
 from .lstm import AttentiveLSTMEncoderDecoder, LSTMEncoderDecoder
 from .pointer_generator import (
@@ -12,7 +12,6 @@ from .pointer_generator import (
 )
 from .transducer import TransducerEncoderDecoder
 from .transformer import TransformerEncoderDecoder
-
 
 _model_fac = {
     "attentive_lstm": AttentiveLSTMEncoderDecoder,

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -10,7 +10,6 @@ from torch import nn, optim
 from .. import data, defaults, evaluators, schedulers, util
 from . import modules
 
-
 _optim_fac = {
     "adadelta": optim.Adadelta,
     "adam": optim.Adam,

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -3,7 +3,7 @@
 import argparse
 from typing import Callable, Dict, Optional, Set
 
-import pytorch_lightning as pl
+import lightning
 import torch
 from torch import nn, optim
 
@@ -23,7 +23,7 @@ _scheduler_fac = {
 }
 
 
-class BaseEncoderDecoder(pl.LightningModule):
+class BaseEncoderDecoder(lightning.LightningModule):
     """Base class, handling Lightning integration."""
 
     #  TODO: clean up type checking here.

--- a/yoyodyne/models/expert.py
+++ b/yoyodyne/models/expert.py
@@ -12,8 +12,8 @@ import argparse
 import dataclasses
 from typing import Any, Dict, Iterable, Iterator, List, Sequence, Set, Tuple
 
-from maxwell import actions, sed
 import numpy
+from maxwell import actions, sed
 from torch.utils import data
 
 from .. import defaults

--- a/yoyodyne/models/modules/base.py
+++ b/yoyodyne/models/modules/base.py
@@ -4,7 +4,7 @@
 import dataclasses
 from typing import Optional, Tuple
 
-import pytorch_lightning as pl
+import lightning
 import torch
 from torch import nn
 
@@ -28,7 +28,7 @@ class ModuleOutput:
         return self.embeddings is not None
 
 
-class BaseModule(pl.LightningModule):
+class BaseModule(lightning.LightningModule):
     # Indices.
     pad_idx: int
     start_idx: int

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -1,8 +1,8 @@
 """Pointer-generator model classes."""
 
-import numpy
 from typing import Callable, Optional, Tuple
 
+import numpy
 import torch
 from torch import nn
 

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -2,9 +2,9 @@
 
 from typing import Callable, Dict, List, Optional, Tuple
 
-from maxwell import actions
 import numpy
 import torch
+from maxwell import actions
 from torch import nn
 
 from .. import data, defaults, util

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -3,23 +3,23 @@
 import argparse
 import os
 
-import pytorch_lightning as pl
+import lightning
 
 from . import data, defaults, models, util
 
 
 def get_trainer_from_argparse_args(
     args: argparse.Namespace,
-) -> pl.Trainer:
+) -> lightning.Trainer:
     """Creates the trainer from CLI arguments.
 
     Args:
         args (argparse.Namespace).
 
     Return:
-        pl.Trainer.
+        lightning.Trainer.
     """
-    return pl.Trainer.from_argparse_args(args, max_epochs=0)
+    return lightning.Trainer.from_argparse_args(args, max_epochs=0)
 
 
 def get_datamodule_from_argparse_args(
@@ -82,7 +82,7 @@ def _mkdir(output: str) -> None:
 
 
 def predict(
-    trainer: pl.Trainer,
+    trainer: lightning.Trainer,
     model: models.BaseEncoderDecoder,
     datamodule: data.DataModule,
     output: str,
@@ -90,8 +90,8 @@ def predict(
     """Predicts from the model.
 
     Args:
-         trainer (pl.Trainer).
-         model (pl.LightningModule).
+         trainer (lightning.Trainer).
+         model (lightning.LightningModule).
          datamodule (data.DataModule).
          output (str).
     """
@@ -144,7 +144,7 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
     # Among the things this adds, the following are likely to be useful:
     # --accelerator ("gpu" for GPU)
     # --devices (for multiple device support)
-    pl.Trainer.add_argparse_args(parser)
+    lightning.Trainer.add_argparse_args(parser)
 
 
 def main() -> None:

--- a/yoyodyne/schedulers.py
+++ b/yoyodyne/schedulers.py
@@ -1,9 +1,9 @@
 """Custom schedulers."""
 
 import argparse
-import numpy
 from typing import Dict
 
+import numpy
 from torch import optim
 
 from . import defaults, metrics

--- a/yoyodyne/sizing.py
+++ b/yoyodyne/sizing.py
@@ -4,8 +4,8 @@ import argparse
 from typing import Tuple
 
 import lightning
-from lightning.pytorch.tuner import tuning
 import numpy
+from lightning.pytorch.tuner import tuning
 
 from . import data, defaults, models, util
 

--- a/yoyodyne/sizing.py
+++ b/yoyodyne/sizing.py
@@ -3,9 +3,9 @@
 import argparse
 from typing import Tuple
 
+import lightning
+from lightning.pytorch.tuner import tuning
 import numpy
-import pytorch_lightning as pl
-from pytorch_lightning.tuner import tuning
 
 from . import data, defaults, models, util
 
@@ -50,7 +50,7 @@ def _optimal_batch_size(
 
 def find_batch_size(
     method: str,
-    trainer: pl.Trainer,
+    trainer: lightning.Trainer,
     model: models.BaseEncoderDecoder,
     datamodule: data.DataModule,
     *,
@@ -72,7 +72,7 @@ def find_batch_size(
         method (str): one of "max" (find the maximum batch size) or "opt" (find
             the "optimal" batch size, using the gradient accumulation trick if
             necessary.)
-        trainer (pl.Trainer).
+        trainer (lightning.Trainer).
         model (models.BaseEncoderDecoder).
         datamodule (data.DataModule).
         steps_per_trial (int, optional): number of steps to run with a given

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -3,9 +3,9 @@
 import argparse
 from typing import List, Optional
 
-import pytorch_lightning as pl
+import lightning
+from lightning.pytorch import callbacks, loggers
 import wandb
-from pytorch_lightning import callbacks, loggers
 
 from . import (
     data,
@@ -104,16 +104,16 @@ def _get_callbacks(
 
 def get_trainer_from_argparse_args(
     args: argparse.Namespace,
-) -> pl.Trainer:
+) -> lightning.Trainer:
     """Creates the trainer from CLI arguments.
 
     Args:
         args (argparse.Namespace).
 
     Returns:
-        pl.Trainer.
+        lightning.Trainer.
     """
-    return pl.Trainer.from_argparse_args(
+    return lightning.Trainer.from_argparse_args(
         args,
         callbacks=_get_callbacks(
             args.num_checkpoints,
@@ -289,7 +289,7 @@ def train(args: argparse.Namespace) -> str:
     """
     if args.log_wandb:
         wandb.init()
-    pl.seed_everything(args.seed)
+    lightning.seed_everything(args.seed)
     trainer = get_trainer_from_argparse_args(args)
     datamodule = get_datamodule_from_argparse_args(args)
     model = get_model_from_argparse_args(args, datamodule)
@@ -415,7 +415,7 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
     # --max_steps
     # --min_steps
     # --max_time
-    pl.Trainer.add_argparse_args(parser)
+    lightning.Trainer.add_argparse_args(parser)
 
 
 def main() -> None:

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -4,8 +4,8 @@ import argparse
 from typing import List, Optional
 
 import lightning
-from lightning.pytorch import callbacks, loggers
 import wandb
+from lightning.pytorch import callbacks, loggers
 
 from . import (
     data,

--- a/yoyodyne/util.py
+++ b/yoyodyne/util.py
@@ -2,11 +2,9 @@
 
 import argparse
 import sys
-
-import torch
-
 from typing import Any, Optional
 
+import torch
 
 # Argument parsing.
 


### PR DESCRIPTION
This is no-op basically; we just have to change some of the imports and the requirements.

Closes #238.