### PR TITLE
Moves parameter counting into base model

### DIFF
--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -200,6 +200,10 @@ class BaseEncoderDecoder(lightning.LightningModule):
         raise NotImplementedError
 
     @property
+    def num_parameters(self) -> int:
+        return sum(part.numel() for part in self.parameters())
+
+    @property
     def has_features_encoder(self):
         return self.features_encoder is not None
 

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -294,10 +294,7 @@ def train(args: argparse.Namespace) -> str:
     datamodule = get_datamodule_from_argparse_args(args)
     model = get_model_from_argparse_args(args, datamodule)
     if args.log_wandb:
-        # Logs number of model parameters for W&B.
-        wandb.config["n_model_params"] = sum(
-            p.numel() for p in model.parameters()
-        )
+        wandb.config["num_parameters"] = model.num_parameters
     if args.find_batch_size:
         sizing.find_batch_size(
             args.find_batch_size,


### PR DESCRIPTION
We have special logic inside the trainer which logs, to W&B (and only if enabled), the number of parameters. This makes two changes:

1. the actual logic into summing the parameters across the elements is moved into the base model.
2. the name of the logged quantity is given a more informative name.

Nothing else changed.