### PR TITLE
Removes `dtype=torch.long` declarations

### DIFF
--- a/yoyodyne/data/datasets.py
+++ b/yoyodyne/data/datasets.py
@@ -73,10 +73,7 @@ class Dataset(data.Dataset):
         Returns:
             torch.Tensor: the encoded tensor.
         """
-        return torch.tensor(
-            [self.index(symbol) for symbol in symbols],
-            dtype=torch.long,
-        )
+        return torch.tensor([self.index(symbol) for symbol in symbols])
 
     def encode_source(self, symbols: List[str]) -> torch.Tensor:
         """Encodes a source string, padding with start and end tags.

--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -81,9 +81,7 @@ class HardAttentionRNNModel(rnn.RNNModel):
         batch_size = encoder_mask.shape[0]
         decoder_hiddens = self.init_hiddens(batch_size)
         bos = (
-            torch.tensor(
-                [special.START_IDX], device=self.device, dtype=torch.long
-            )
+            torch.tensor([special.START_IDX], device=self.device)
             .repeat(batch_size)
             .unsqueeze(-1)
         )

--- a/yoyodyne/models/modules/transformer.py
+++ b/yoyodyne/models/modules/transformer.py
@@ -64,7 +64,7 @@ class PositionalEncoding(nn.Module):
             # Indices should all be 0's until the first unmasked position.
             indices = torch.cumsum(mask, dim=1)
         else:
-            indices = torch.arange(symbols.size(1)).long()
+            indices = torch.arange(symbols.size(1))
         # Selects the tensors from `out` at the specified indices.
         out = out[torch.arange(out.shape[0]).unsqueeze(-1), indices]
         # Zeros out pads.
@@ -260,9 +260,7 @@ class FeatureInvariantTransformerEncoder(TransformerEncoder):
                 B x seq_len x embed_dim.
         """
         # Distinguishes features and chars; 1 or 0.
-        char_mask = (
-            symbols < (self.num_embeddings - self.features_vocab_size)
-        ).long()
+        char_mask = symbols < (self.num_embeddings - self.features_vocab_size)
         type_embedding = self.esq * self.type_embedding(char_mask)
         word_embedding = self.esq * self.embeddings(symbols)
         positional_embedding = self.positional_encoding(

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -258,13 +258,13 @@ class PointerGeneratorRNNModel(rnn.RNNModel, PointerGenerator):
         # -> B x 1 x target_vocab_size.
         ptr_dist = torch.zeros(
             symbol.size(0),
+            1,
             self.target_vocab_size,
             device=self.device,
             dtype=attention_weights.dtype,
-        ).unsqueeze(1)
+        )
         # Gets the attentions to the source in terms of the output generations.
         # These are the "pointer" distribution.
-        # -> B x 1 x target_vocab_size.
         ptr_dist.scatter_add_(
             2, source_indices.unsqueeze(1), attention_weights
         )
@@ -315,7 +315,8 @@ class PointerGeneratorRNNModel(rnn.RNNModel, PointerGenerator):
         # -> B x 1
         decoder_input = (
             torch.tensor(
-                [special.START_IDX], device=self.device, dtype=torch.long
+                [special.START_IDX],
+                device=self.device,
             )
             .repeat(batch_size)
             .unsqueeze(1)
@@ -432,10 +433,11 @@ class PointerGeneratorGRUModel(PointerGeneratorRNNModel, rnn.GRUModel):
         # -> B x 1 x target_vocab_size.
         ptr_dist = torch.zeros(
             symbol.size(0),
+            1,
             self.target_vocab_size,
             device=self.device,
             dtype=attention_weights.dtype,
-        ).unsqueeze(1)
+        )
         # Gets the attentions to the source in terms of the output generations.
         # These are the "pointer" distribution.
         # -> B x 1 x target_vocab_size.
@@ -597,10 +599,11 @@ class PointerGeneratorLSTMModel(PointerGeneratorRNNModel, rnn.LSTMModel):
         # -> B x 1 x target_vocab_size.
         ptr_dist = torch.zeros(
             symbol.size(0),
+            1,
             self.target_vocab_size,
             device=self.device,
             dtype=attention_weights.dtype,
-        ).unsqueeze(1)
+        )
         # Gets the attentions to the source in terms of the output generations.
         # These are the "pointer" distribution.
         # -> B x 1 x target_vocab_size.
@@ -915,9 +918,7 @@ class PointerGeneratorTransformerModel(
             ), "Teacher forcing requested but no target provided"
             # Initializes the start symbol for decoding.
             starts = (
-                torch.tensor(
-                    [special.START_IDX], device=self.device, dtype=torch.long
-                )
+                torch.tensor([special.START_IDX], device=self.device)
                 .repeat(batch.target.padded.size(0))
                 .unsqueeze(1)
             )

--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -75,9 +75,7 @@ class RNNModel(base.BaseModel):
         # Feed in the first decoder input, as a start tag.
         # -> B x 1.
         decoder_input = (
-            torch.tensor(
-                [special.START_IDX], device=self.device, dtype=torch.long
-            )
+            torch.tensor([special.START_IDX], device=self.device)
             .repeat(batch_size)
             .unsqueeze(1)
         )
@@ -167,7 +165,8 @@ class RNNModel(base.BaseModel):
                 # Feeds in the first decoder input, as a start tag.
                 # -> batch_size x 1
                 decoder_input = torch.tensor(
-                    [beam_idxs[-1]], device=self.device, dtype=torch.long
+                    [beam_idxs[-1]],
+                    device=self.device,
                 ).unsqueeze(1)
                 decoded = self.decoder(
                     decoder_input, decoder_hiddens, encoder_out, encoder_mask

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -150,7 +150,6 @@ class TransformerModel(base.BaseModel):
                 torch.tensor(
                     [special.START_IDX],
                     device=self.device,
-                    dtype=torch.long,
                 )
                 .repeat(batch.target.padded.size(0))
                 .unsqueeze(1)


### PR DESCRIPTION
I know of no reason to think these are necessary.

I also simplify the creation of the pointer distribution tensor. Since this is made with `zeros` one can just have dimension 1 be size 1 at creation; the `unsqueeze` call is unnecessary.

Closes #236.