### PR TITLE
Migrates to LightningCLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ provide any symbols of the form `<...>`, `[...]`, or `{...}`.
 Checkpointing is handled by
 [Lightning](https://pytorch-lightning.readthedocs.io/en/stable/common/checkpointing_basic.html).
 The path for model information, including checkpoints, is specified by
-`--model_dir` such that we build the path `model_dir/version_n`,
-where each run of an experiment with the same `model_dir` is namespaced with a
-new version number. A version stores all of the following:
+`--model_dir` such that we build the path `model_dir/version_n`, where each run
+of an experiment with the same `model_dir` is namespaced with a new version
+number. A version stores all of the following:
 
 -   the index (`model_dir/index.pkl`),
 -   the hyperparameters (`model_dir/lightning_logs/version_n/hparams.yaml`),
@@ -288,7 +288,9 @@ A non-exhaustive list includes:
 -   Seeding:
     -   `--seed`
 -   [Weights & Biases](https://wandb.ai/site):
-    -   `--log_wandb` (default: `False`): enables Weights & Biases tracking
+    -   `--log_wandb` (default: `False`): enables Weights & Biases tracking; the
+        "project" name can be specified using the environmental variable
+        `$WANDB_PROJECT`.
 
 Additional training options are discussed below.
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ One must specify the following required arguments:
 
 -   `--arch`: architecture, matching the one used for training
 -   `--model_dir`: path for model metadata
--   `--experiment`: name of experiment
 -   `--checkpoint`: path to checkpoint
 -   `--predict`: path to file containing data to be predicted
 -   `--output`: path for predictions

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Training is performed by the [`yoyodyne-train`](yoyodyne/train.py) script. One
 must specify the following required arguments:
 
 -   `--model_dir`: path for model metadata and checkpoints
--   `--experiment`: name of experiment (pick something unique)
 -   `--train`: path to TSV file containing training data
 -   `--val`: path to TSV file containing validation data
 
@@ -161,13 +160,15 @@ provide any symbols of the form `<...>`, `[...]`, or `{...}`.
 
 Checkpointing is handled by
 [Lightning](https://pytorch-lightning.readthedocs.io/en/stable/common/checkpointing_basic.html).
-The path for model information, including checkpoints, is specified by a
-combination of `--model_dir` and `--experiment`, such that we build the path
-`model_dir/experiment/version_n`, where each run of an experiment with the same
-`model_dir` and `experiment` is namespaced with a new version number. A version
-stores everything needed to reload the model, including the hyperparameters
-(`model_dir/experiment_name/version_n/hparams.yaml`) and the checkpoints
-directory (`model_dir/experiment_name/version_n/checkpoints`).
+The path for model information, including checkpoints, is specified by
+`--model_dir` such that we build the path `model_dir/version_n`,
+where each run of an experiment with the same `model_dir` is namespaced with a
+new version number. A version stores all of the following:
+
+-   the index (`model_dir/index.pkl`),
+-   the hyperparameters (`model_dir/lightning_logs/version_n/hparams.yaml`),
+-   the metrics (`model_dir/lightning_logs/version_n/metrics.csv`), and
+-   the checkpoints (`model_dir/lightning_logs/version_n/checkpoints`).
 
 By default, each run initializes a new model from scratch, unless the
 `--train_from` argument is specified. To continue training from a specific

--- a/README.md
+++ b/README.md
@@ -159,10 +159,11 @@ provide any symbols of the form `<...>`, `[...]`, or `{...}`.
 
 Checkpointing is handled by
 [Lightning](https://pytorch-lightning.readthedocs.io/en/stable/common/checkpointing_basic.html).
-The path for model information, including checkpoints, is specified by
-`--model_dir` such that we build the path `model_dir/version_n`, where each run
-of an experiment with the same `model_dir` is namespaced with a new version
-number. A version stores all of the following:
+The path for model information, including checkpoints, is specified by a
+combination of `--model_dir` such that we build the path `model_dir/version_n`,
+where each run of an experiment with the same `model_dir` is namespaced with a
+new version number. A version stores everything needed to reload the model,
+including:
 
 -   the index (`model_dir/index.pkl`),
 -   the hyperparameters (`model_dir/lightning_logs/version_n/hparams.yaml`),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = ["examples*"]
 
 [project]
 name = "yoyodyne"
-version = "0.2.14"
+version = "0.3.0"
 description = "Small-vocabulary neural sequence-to-sequence models"
 readme = "README.md"
 requires-python = ">= 3.9"
@@ -29,9 +29,7 @@ keywords = [
 ]
 dependencies = [
     "maxwell >= 0.2.5",
-    # TODO: allow >= 2.0.0 once we we migrate to lightning >= 2.0.0".
-    "numpy >= 1.26.0, < 2.0.0", 
-    "lightning >= 1.7.0, < 2.0.0",
+    "lightning >= 2.4.0",
     "torch >= 2.5.1",
     "wandb >= 0.18.5",
 ]
@@ -49,8 +47,7 @@ classifiers = [
 ]
 
 [project.scripts]
-yoyodyne-predict = "yoyodyne.predict:main"
-yoyodyne-train = "yoyodyne.train:main"
+yoyodyne = "yoyodyne.cli:main"
 
 [project.urls]
 homepage = "https://github.com/CUNY-CL/yoyodyne"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 black>=24.10.0
 build>=1.2.1
 flake8>=7.1.0
-lightning>=1.7.0,<2.0.0
+lightning>=2.4.0
 maxwell>=0.2.5
-numpy>=1.26.0,<2.0.0
+numpy>=2.0.0
 pandas>=2.2.2
 pytest>=8.3.2
 scipy>=1.13.1
@@ -12,4 +12,4 @@ torch>=2.5.1
 tqdm>=4.66.6
 twine>=5.1.1
 wandb>=0.18.5
-wheel>=0.40.0
+wheel>=0.45.0

--- a/yoyodyne/data/__init__.py
+++ b/yoyodyne/data/__init__.py
@@ -5,9 +5,10 @@ import argparse
 from .. import defaults
 from .batches import PaddedBatch, PaddedTensor  # noqa: F401
 from .datamodules import DataModule  # noqa: F401
+from .datasets import Dataset  # noqa: F401
 from .indexes import Index  # noqa: F401
 from .mappers import Mapper  # noqa: F401
-from .parser import TsvParser  # noqa: F401
+from .tsv import TsvParser  # noqa: F401
 
 
 def add_argparse_args(parser: argparse.ArgumentParser) -> None:

--- a/yoyodyne/data/__init__.py
+++ b/yoyodyne/data/__init__.py
@@ -5,8 +5,9 @@ import argparse
 from .. import defaults
 from .batches import PaddedBatch, PaddedTensor  # noqa: F401
 from .datamodules import DataModule  # noqa: F401
-from .datasets import Dataset  # noqa: F401
 from .indexes import Index  # noqa: F401
+from .mappers import Mapper  # noqa: F401
+from .parser import TsvParser  # noqa: F401
 
 
 def add_argparse_args(parser: argparse.ArgumentParser) -> None:

--- a/yoyodyne/data/collators.py
+++ b/yoyodyne/data/collators.py
@@ -2,6 +2,7 @@
 
 import argparse
 import dataclasses
+
 from typing import List
 
 import torch

--- a/yoyodyne/data/datamodules.py
+++ b/yoyodyne/data/datamodules.py
@@ -128,9 +128,9 @@ class DataModule(lightning.LightningDataModule):
                 f"{self.pprint(self.index.target_vocabulary)}"
             )
 
-    def write_index(self, model_dir: str, experiment: str) -> None:
+    def write_index(self, model_dir: str) -> None:
         """Writes the index."""
-        self.index.write(model_dir, experiment)
+        self.index.write(model_dir)
 
     @property
     def has_features(self) -> bool:

--- a/yoyodyne/data/datamodules.py
+++ b/yoyodyne/data/datamodules.py
@@ -1,6 +1,6 @@
 """Data modules."""
 
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Set
 
 import lightning
 from torch.utils import data
@@ -89,9 +89,13 @@ class DataModule(lightning.LightningDataModule):
     def _make_index(
         self, model_dir: str, tie_embeddings: bool
     ) -> indexes.Index:
-        source_vocabulary = set()
-        features_vocabulary = set() if self.has_features else None
-        target_vocabulary = set() if self.has_target else None
+        source_vocabulary: Set[str] = set()
+        features_vocabulary: Optional[Set[str]] = (
+            set() if self.has_features else None
+        )
+        target_vocabulary: Optional[Set[str]] = (
+            set() if self.has_target else None
+        )
         if self.has_features:
             if self.has_target:
                 for source, features, target in self.parser.samples(

--- a/yoyodyne/data/datamodules.py
+++ b/yoyodyne/data/datamodules.py
@@ -6,7 +6,7 @@ import lightning
 from torch.utils import data
 
 from .. import defaults, util
-from . import collators, datasets, indexes, tsv
+from . import collators, datasets, indexes, mappers, tsv
 
 
 class DataModule(lightning.LightningDataModule):
@@ -48,8 +48,8 @@ class DataModule(lightning.LightningDataModule):
         features_sep: str = defaults.FEATURES_SEP,
         target_sep: str = defaults.TARGET_SEP,
         # Modeling options.
-        tie_embeddings: bool = defaults.TIE_EMBEDDINGS,
         separate_features: bool = False,
+        tie_embeddings: bool = defaults.TIE_EMBEDDINGS,
         # Other.
         batch_size: int = defaults.BATCH_SIZE,
         max_source_length: int = defaults.MAX_SOURCE_LENGTH,
@@ -213,6 +213,6 @@ class DataModule(lightning.LightningDataModule):
     def _dataset(self, path: str) -> datasets.Dataset:
         return datasets.Dataset(
             list(self.parser.samples(path)),
-            self.index,
+            mappers.Mapper(self.index),
             self.parser,
         )

--- a/yoyodyne/data/datasets.py
+++ b/yoyodyne/data/datasets.py
@@ -1,18 +1,13 @@
-"""Datasets and related utilities.
-
-Anything which has a tensor member should inherit from nn.Module, run the
-superclass constructor, and register the tensor as a buffer. This enables the
-Trainer to move them to the appropriate device."""
+"""Datasets and related utilities."""
 
 import dataclasses
-from typing import Iterator, List, Optional
+from typing import List, Optional
 
 import torch
 from torch import nn
 from torch.utils import data
 
-from .. import special
-from . import indexes, tsv
+from . import mappers, tsv
 
 
 class Item(nn.Module):
@@ -45,139 +40,20 @@ class Item(nn.Module):
         return self.target is not None
 
 
+# TODO: Add an iterable data set object for out-of-core inference.
+
+
 @dataclasses.dataclass
 class Dataset(data.Dataset):
-    """Datatset class."""
+    """Mappable data set.
+
+    This class loads the entire file into memory and is therefore only suitable
+    for in-core data sets.
+    """
 
     samples: List[tsv.SampleType]
-    index: indexes.Index  # Usually copied from the DataModule.
+    mapper: mappers.Mapper
     parser: tsv.TsvParser  # Ditto.
-
-    @property
-    def has_features(self) -> bool:
-        return self.parser.has_features
-
-    @property
-    def has_target(self) -> bool:
-        return self.parser.has_target
-
-    def _encode(
-        self,
-        symbols: List[str],
-    ) -> torch.Tensor:
-        """Encodes a sequence as a tensor of indices with string boundary IDs.
-
-        Args:
-            symbols (List[str]): symbols to be encoded.
-
-        Returns:
-            torch.Tensor: the encoded tensor.
-        """
-        return torch.tensor([self.index(symbol) for symbol in symbols])
-
-    def encode_source(self, symbols: List[str]) -> torch.Tensor:
-        """Encodes a source string, padding with start and end tags.
-
-        Args:
-            symbols (List[str]).
-
-        Returns:
-            torch.Tensor.
-        """
-        wrapped = [special.START]
-        wrapped.extend(symbols)
-        wrapped.append(special.END)
-        return self._encode(wrapped)
-
-    def encode_features(self, symbols: List[str]) -> torch.Tensor:
-        """Encodes a features string.
-
-        Args:
-            symbols (List[str]).
-
-        Returns:
-            torch.Tensor.
-        """
-        return self._encode(symbols)
-
-    def encode_target(self, symbols: List[str]) -> torch.Tensor:
-        """Encodes a features string, padding with end tags.
-
-        Args:
-            symbols (List[str]).
-
-        Returns:
-            torch.Tensor.
-        """
-        wrapped = symbols.copy()
-        wrapped.append(special.END)
-        return self._encode(wrapped)
-
-    # Decoding.
-
-    def _decode(
-        self,
-        indices: torch.Tensor,
-    ) -> Iterator[List[str]]:
-        """Decodes the tensor of indices into lists of symbols.
-
-        Args:
-            indices (torch.Tensor): 2d tensor of indices.
-
-        Yields:
-            List[str]: Decoded symbols.
-        """
-        for idx in indices.cpu():
-            yield [
-                self.index.get_symbol(c)
-                for c in idx
-                if not special.isspecial(c)
-            ]
-
-    def decode_source(
-        self,
-        indices: torch.Tensor,
-    ) -> Iterator[str]:
-        """Decodes a source tensor.
-
-        Args:
-            indices (torch.Tensor): 2d tensor of indices.
-
-        Yields:
-            str: Decoded source strings.
-        """
-        for symbols in self._decode(indices):
-            yield self.parser.source_string(symbols)
-
-    def decode_features(
-        self,
-        indices: torch.Tensor,
-    ) -> Iterator[str]:
-        """Decodes a features tensor.
-
-        Args:
-            indices (torch.Tensor): 2d tensor of indices.
-
-        Yields:
-            str: Decoded features strings.
-        """
-        for symbols in self._decode(indices):
-            yield self.parser.feature_string(symbols)
-
-    def decode_target(
-        self,
-        indices: torch.Tensor,
-    ) -> Iterator[str]:
-        """Decodes a target tensor.
-
-        Args:
-            indices (torch.Tensor): 2d tensor of indices.
-
-        Yields:
-            str: Decoded target strings.
-        """
-        for symbols in self._decode(indices):
-            yield self.parser.target_string(symbols)
 
     # Required API.
 
@@ -193,26 +69,27 @@ class Dataset(data.Dataset):
         Returns:
             Item.
         """
+        row = self.samples[idx]
         if self.has_features:
             if self.has_target:
-                source, features, target = self.samples[idx]
+                source, features, target = row
                 return Item(
-                    source=self.encode_source(source),
-                    features=self.encode_features(features),
-                    target=self.encode_target(target),
+                    source=self.mapper.encode_source(source),
+                    features=self.mapper.encode_features(features),
+                    target=self.mapper.encode_target(target),
                 )
             else:
-                source, features = self.samples[idx]
+                source, features = row
                 return Item(
-                    source=self.encode_source(source),
-                    features=self.encode_features(features),
+                    source=self.mapper.encode_source(source),
+                    features=self.mapper.encode_features(features),
                 )
         elif self.has_target:
-            source, target = self.samples[idx]
+            source, target = row
             return Item(
-                source=self.encode_source(source),
-                target=self.encode_target(target),
+                source=self.mapper.encode_source(source),
+                target=self.mapper.encode_target(target),
             )
         else:
-            source = self.samples[idx]
-            return Item(source=self.encode_source(source))
+            source = row
+            return Item(source=self.mapper.encode_source(source))

--- a/yoyodyne/data/datasets.py
+++ b/yoyodyne/data/datasets.py
@@ -1,6 +1,7 @@
 """Datasets and related utilities."""
 
 import dataclasses
+
 from typing import List, Optional
 
 import torch

--- a/yoyodyne/data/datasets.py
+++ b/yoyodyne/data/datasets.py
@@ -55,6 +55,16 @@ class Dataset(data.Dataset):
     mapper: mappers.Mapper
     parser: tsv.TsvParser  # Ditto.
 
+    # Properties.
+
+    @property
+    def has_features(self) -> bool:
+        return self.parser.has_features
+
+    @property
+    def has_target(self) -> bool:
+        return self.parser.has_target
+
     # Required API.
 
     def __len__(self) -> int:
@@ -69,27 +79,27 @@ class Dataset(data.Dataset):
         Returns:
             Item.
         """
-        row = self.samples[idx]
+        sample = self.samples[idx]
         if self.has_features:
             if self.has_target:
-                source, features, target = row
+                source, features, target = sample
                 return Item(
                     source=self.mapper.encode_source(source),
                     features=self.mapper.encode_features(features),
                     target=self.mapper.encode_target(target),
                 )
             else:
-                source, features = row
+                source, features = sample
                 return Item(
                     source=self.mapper.encode_source(source),
                     features=self.mapper.encode_features(features),
                 )
         elif self.has_target:
-            source, target = row
+            source, target = sample
             return Item(
                 source=self.mapper.encode_source(source),
                 target=self.mapper.encode_target(target),
             )
         else:
-            source = row
+            source = sample
             return Item(source=self.mapper.encode_source(source))

--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import itertools
 import pickle
+
 from typing import Dict, Iterable, List, Optional
 
 from .. import defaults, special, util

--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import itertools
 import pickle
 from typing import Dict, Iterable, List, Optional
 
@@ -49,7 +50,9 @@ class Index:
         if self.tie_embeddings:
             # Vocabulary is the union of source and target.
             vocabulary = sorted(
-                frozenset(source_vocabulary + target_vocabulary)
+                frozenset(
+                    itertools.chain(source_vocabulary, target_vocabulary)
+                )
             )
         else:
             # Vocabulary consists of target symbols followed by source symbols.

--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -1,5 +1,7 @@
 """Symbol index."""
 
+from __future__ import annotations
+
 import os
 import pickle
 from typing import Dict, Iterable, List, Optional
@@ -87,7 +89,7 @@ class Index:
     # Serialization support.
 
     @classmethod
-    def read(cls, model_dir: str, experiment: str) -> "Index":
+    def read(cls, model_dir: str, experiment: str) -> Index:
         """Loads index.
 
         Args:

--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -86,51 +86,45 @@ class Index:
         """
         return self._index2symbol[index]
 
-    # Serialization support.
+    # Serialization....
 
     @classmethod
-    def read(cls, model_dir: str, experiment: str) -> Index:
+    def read(cls, model_dir: str) -> Index:
         """Loads index.
 
         Args:
             model_dir (str).
-            experiment (str).
 
         Returns:
             Index.
         """
-        index = cls.__new__(cls)
-        path = index.index_path(model_dir, experiment)
-        with open(path, "rb") as source:
-            dictionary = pickle.load(source)
-        for key, value in dictionary.items():
-            setattr(index, key, value)
-        return index
+        with open(cls.path(model_dir), "rb") as source:
+            return pickle.load(source)
 
-    @staticmethod
-    def index_path(model_dir: str, experiment: str) -> str:
-        """Computes path for the index file.
-
-        Args:
-            model_dir (str).
-            experiment (str).
-
-        Returns:
-            str.
-        """
-        return f"{model_dir}/{experiment}/index.pkl"
-
-    def write(self, model_dir: str, experiment: str) -> None:
+    def write(self, model_dir: str) -> None:
         """Writes index.
 
         Args:
             model_dir (str).
-            experiment (str).
         """
-        path = self.index_path(model_dir, experiment)
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        path = self.path(model_dir)
+        os.mkpath(path)
         with open(path, "wb") as sink:
-            pickle.dump(vars(self), sink)
+            pickle.dump(self, sink)
+
+    @staticmethod
+    def path(model_dir: str) -> str:
+        """Computes path for the index file.
+
+        Args:
+            model_dir (str).
+
+        Returns:
+            str.
+        """
+        return f"{model_dir}/index.pkl"
+
+    # Properties.
 
     @property
     def symbols(self) -> List[str]:
@@ -163,25 +157,3 @@ class Index:
             return len(special.SPECIAL) + len(self.target_vocabulary)
         else:
             return 0
-
-    @property
-    def features_vocab_size(self) -> int:
-        return len(self.features_vocabulary) if self.features_vocabulary else 0
-
-    # These are also recorded in the `special` module.
-
-    @property
-    def pad_idx(self) -> int:
-        return self._symbol2index[special.PAD]
-
-    @property
-    def start_idx(self) -> int:
-        return self._symbol2index[special.START]
-
-    @property
-    def end_idx(self) -> int:
-        return self._symbol2index[special.END]
-
-    @property
-    def unk_idx(self) -> int:
-        return self._symbol2index[special.UNK]

--- a/yoyodyne/data/mappers.py
+++ b/yoyodyne/data/mappers.py
@@ -1,0 +1,123 @@
+"""Encodes and decodes tensors."""
+
+from __future__ import annotations
+
+import dataclasses
+
+from typing import Iterable, List
+
+import torch
+
+from . import indexes
+from .. import special
+
+
+@dataclasses.dataclass
+class Mapper:
+    """Handles mapping between strings and tensors."""
+
+    index: indexes.Index  # Usually copied from the DataModule.
+
+    @classmethod
+    def read(cls, model_dir: str) -> Mapper:
+        """Loads mapper from an index.
+
+        Args:
+            model_dir (str).
+
+        Returns:
+            Mapper.
+        """
+        return cls(indexes.Index.read(model_dir))
+
+    # Encoding.
+
+    def _encode(self, symbols: Iterable[str]):
+        """Encodes a tensor.
+
+        Args:
+            ymbols (Iterable[str]).
+
+        Returns:
+            torch.Tensor: the encoded tensor.
+        """
+        return torch.tensor([self.index(symbol) for symbol in symbols])
+
+    def encode_source(self, symbols: Iterable[str]) -> torch.Tensor:
+        """Encodes a source string, padding with start and end tags.
+
+        Args:
+            symbols (Iterable[str]).
+
+        Returns:
+            torch.Tensor.
+        """
+        wrapped = [special.START]
+        wrapped.extend(symbols)
+        wrapped.append(special.END)
+        return self._encode(wrapped)
+
+    def encode_features(self, symbols: Iterable[str]) -> torch.Tensor:
+        """Encodes a features string.
+
+        Args:
+            symbols (Iterable[str]).
+
+        Returns:
+            torch.Tensor.
+        """
+        return self._encode(symbols)
+
+    def encode_target(self, symbols: Iterable[str]) -> torch.Tensor:
+        """Encodes a features string, padding with end tags.
+
+        Args:
+            symbols (Iterable[str]).
+
+        Returns:
+            torch.Tensor.
+        """
+        wrapped = list(symbols)
+        wrapped.append(special.END)
+        return self._encode(wrapped)
+
+    # Decoding.
+
+    def _decode(
+        self,
+        indices: torch.Tensor,
+    ) -> List[str]:
+        """Decodes a tensor.
+
+        Args:
+            indices (torch.Tensor): 1d tensor of indices.
+
+        Yields:
+            List[str]: Decoded symbols.
+        """
+        return [
+            self.index.get_symbol(c)
+            for c in indices
+            if c not in self.index.special_idx
+        ]
+
+    # These are just here for compatibility but they all have
+    # the same implementation.
+
+    def decode_source(
+        self,
+        indices: torch.Tensor,
+    ) -> List[str]:
+        return self._decode(indices)
+
+    def decode_features(
+        self,
+        indices: torch.Tensor,
+    ) -> List[str]:
+        return self._decode(indices)
+
+    def decode_target(
+        self,
+        indices: torch.Tensor,
+    ) -> List[str]:
+        return self._decode(indices)

--- a/yoyodyne/data/mappers.py
+++ b/yoyodyne/data/mappers.py
@@ -98,7 +98,7 @@ class Mapper:
         return [
             self.index.get_symbol(c)
             for c in indices
-            if c not in self.index.special_idx
+            if not special.isspecial(c)
         ]
 
     # These are just here for compatibility but they all have

--- a/yoyodyne/data/tsv.py
+++ b/yoyodyne/data/tsv.py
@@ -6,6 +6,7 @@ separators.
 
 import csv
 import dataclasses
+
 from typing import Iterator, List, Tuple, Union
 
 from .. import defaults

--- a/yoyodyne/evaluators.py
+++ b/yoyodyne/evaluators.py
@@ -136,7 +136,7 @@ class AccuracyEvaluator(Evaluator):
         Returns:
             torch.Tensor: finalized predictions.
         """
-        return util.pad_tensor_after_eos(predictions)
+        return util.pad_tensor_after_end(predictions)
 
     def finalize_golds(
         self,
@@ -197,8 +197,8 @@ class SEREvaluator(Evaluator):
     ) -> List[torch.Tensor]:
         """Finalizes each tensor.
 
-        Truncates at EOS for each prediction and returns a List of predictions.
-        This does basically the same as util.pad_after_eos, but does not
+        Truncates at END for each prediction and returns a List of predictions.
+        This does basically the same as util.pad_after_end, but does not
         actually pad since we do not need to return a well-formed tensor.
 
         Args:
@@ -212,21 +212,21 @@ class SEREvaluator(Evaluator):
             return [tensor]
         out = []
         for prediction in tensor:
-            # Gets first instance of EOS.
-            eos = (prediction == special.END_IDX).nonzero(as_tuple=False)
-            if len(eos) > 0 and eos[0].item() < len(prediction):
-                # If an EOS was decoded and it is not the last one in the
+            # Gets first instance of END.
+            end = (prediction == special.END_IDX).nonzero(as_tuple=False)
+            if len(end) > 0 and end[0].item() < len(prediction):
+                # If an END was decoded and it is not the last one in the
                 # sequence.
-                eos = eos[0]
+                end = end[0]
             else:
                 # Leaves tensor[i] alone.
                 out.append(prediction)
                 continue
-            # Hack in case the first prediction is EOS. In this case
+            # Hack in case the first prediction is END. In this case
             # torch.split will result in an error, so we change these 0's to
-            # 1's, which will make the entire sequence EOS as intended.
-            eos[eos == 0] = 1
-            symbols, *_ = torch.split(prediction, eos)
+            # 1's, which will make the entire sequence END as intended.
+            end[end == 0] = 1
+            symbols, *_ = torch.split(prediction, end)
             out.append(symbols)
         return out
 

--- a/yoyodyne/models/__init__.py
+++ b/yoyodyne/models/__init__.py
@@ -20,6 +20,7 @@ from .rnn import RNNModel  # noqa: F401
 from .transducer import TransducerGRUModel, TransducerLSTMModel  # noqa: F401
 from .transformer import TransformerModel
 
+
 _model_fac = {
     "attentive_gru": AttentiveGRUModel,
     "attentive_lstm": AttentiveLSTMModel,

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -191,11 +191,7 @@ class BaseModel(lightning.LightningModule):
                 hypotheses to return.
 
         Raises:
-            NotImplementedError: This method needs to be overridden.
-
-        Returns:
-            Tuple[torch.Tensor, torch.Tensor]: the predictions tensor and the
-                log-likelihood of each prediction.
+            NotImplementedError: beam search not implemented.
         """
         raise NotImplementedError(
             f"Beam search not implemented for {self.name} model"

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -176,24 +176,6 @@ class BaseModel(lightning.LightningModule):
     def get_decoder(self):
         raise NotImplementedError
 
-    def beam_decode(
-        self,
-        encoder_out: torch.Tensor,
-        mask: torch.Tensor,
-    ):
-        """Method interface for beam search.
-
-        Args:
-            encoder_out (torch.Tensor).
-            encoder_mask (torch.Tensor).
-
-        Raises:
-            NotImplementedError: beam search not implemented.
-        """
-        raise NotImplementedError(
-            f"Beam search not implemented for {self.name} model"
-        )
-
     @property
     def num_parameters(self) -> int:
         return sum(part.numel() for part in self.parameters())

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -180,15 +180,12 @@ class BaseModel(lightning.LightningModule):
         self,
         encoder_out: torch.Tensor,
         mask: torch.Tensor,
-        beam_width: int,
     ):
         """Method interface for beam search.
 
         Args:
-            encoder_out (torch.Tensor): encoded inputs.
+            encoder_out (torch.Tensor).
             encoder_mask (torch.Tensor).
-            beam_width (int): size of the beam; also determines the number of
-                hypotheses to return.
 
         Raises:
             NotImplementedError: beam search not implemented.

--- a/yoyodyne/models/expert.py
+++ b/yoyodyne/models/expert.py
@@ -433,7 +433,7 @@ class Expert(abc.ABC):
 
 
 def get_expert(
-    train_data: data.Dataset,
+    dataset: data.Dataset,
     index: data.Index,
     epochs: int = defaults.ORACLE_EM_EPOCHS,
     oracle_factor: int = defaults.ORACLE_FACTOR,
@@ -443,7 +443,7 @@ def get_expert(
     """Generates expert object for training transducer.
 
     Args:
-        data (data.Dataset): dataset for generating expert vocabulary.
+        dataset (data.Dataset): dataset for generating expert vocabulary.
         index (data.Index): index for mapping symbols to indices.
         epochs (int): number of EM epochs.
         oracle_factor (float): scaling factor to determine rate of
@@ -458,7 +458,7 @@ def get_expert(
     """
 
     def _generate_data(
-        data: data.Dataset,
+        dataset: data.Dataset,
         index: data.Index,
     ) -> Iterator[Tuple[List[int], List[int]]]:
         """Helper function to manage data encoding for SED."
@@ -467,28 +467,28 @@ def get_expert(
         source-target text for the Maxwell library.
 
         Args:
-            data (data.Dataset): dataset for generating expert vocabulary.
+            dataset (data.Dataset): dataset for generating expert vocabulary.
             index (data.Index): index for mapping symbols to indices.
 
         Yields:
             Tuple[List[int, List[int]]]: lists of source and target entries.
         """
-        if not data.has_target:
+        if not dataset.has_target:
             raise Error("Dataset has no target")
-        for sample in data.samples:
+        for sample in dataset.samples:
             source, *_, target = sample
             yield (
                 [index(symbol) for symbol in source],
                 [index(symbol) for symbol in target],
             )
 
-    actions = ActionVocabulary(train_data.index)
+    actions = ActionVocabulary(index)
     if read_from_file:
         sed_params = sed.ParamDict.read_params(sed_params_path)
         sed_aligner = sed.StochasticEditDistance(sed_params)
     else:
         sed_aligner = sed.StochasticEditDistance.fit_from_data(
-            _generate_data(train_data),
+            _generate_data(dataset, index),
             epochs=epochs,
         )
         sed_aligner.params.write_params(sed_params_path)

--- a/yoyodyne/models/expert.py
+++ b/yoyodyne/models/expert.py
@@ -27,11 +27,15 @@ from maxwell import actions, sed
 from .. import data, defaults
 
 
-class ActionError(Exception):
+class Error(Exception):
     pass
 
 
-class AlignerError(Exception):
+class ActionError(Error):
+    pass
+
+
+class AlignerError(Error):
     pass
 
 
@@ -430,6 +434,7 @@ class Expert(abc.ABC):
 
 def get_expert(
     train_data: data.Dataset,
+    index: data.Index,
     epochs: int = defaults.ORACLE_EM_EPOCHS,
     oracle_factor: int = defaults.ORACLE_FACTOR,
     sed_params_path: str = None,
@@ -439,6 +444,7 @@ def get_expert(
 
     Args:
         data (data.Dataset): dataset for generating expert vocabulary.
+        index (data.Index): index for mapping symbols to indices.
         epochs (int): number of EM epochs.
         oracle_factor (float): scaling factor to determine rate of
             expert rollout sampling.
@@ -453,27 +459,28 @@ def get_expert(
 
     def _generate_data(
         data: data.Dataset,
+        index: data.Index,
     ) -> Iterator[Tuple[List[int], List[int]]]:
         """Helper function to manage data encoding for SED."
 
-        We want encodings without BOS or EOS tokens. This
-        encodes only raw source-target text for the Maxwell library.
+        We want encodings without BOS or EOS tokens. This encodes only raw
+        source-target text for the Maxwell library.
 
         Args:
-            data (data.Dataset): Dataset to iterate over.
+            data (data.Dataset): dataset for generating expert vocabulary.
+            index (data.Index): index for mapping symbols to indices.
 
-        Returns:
-            Iterator[Tuple[List[int], List[int]]]: Iterator that
-                yields list version of source and target entries
-                in dataset.
+        Yields:
+            Tuple[List[int, List[int]]]: lists of source and target entries.
         """
-        assert data.has_target, """Passed dataset with no target to expert
-            module, cannot perform SED"""
+        if not data.has_target:
+            raise Error("Dataset has no target")
         for sample in data.samples:
-            source, target = sample[0], sample[-1]
-            yield [data.index(s) for s in source], [
-                data.index(t) for t in target
-            ]
+            source, *_, target = sample
+            yield (
+                [index(symbol) for symbol in source],
+                [index(symbol) for symbol in target],
+            )
 
     actions = ActionVocabulary(train_data.index)
     if read_from_file:

--- a/yoyodyne/models/expert.py
+++ b/yoyodyne/models/expert.py
@@ -463,8 +463,8 @@ def get_expert(
     ) -> Iterator[Tuple[List[int], List[int]]]:
         """Helper function to manage data encoding for SED."
 
-        We want encodings without BOS or EOS tokens. This encodes only raw
-        source-target text for the Maxwell library.
+        We want encodings without BOS or END tokens. This
+        encodes only raw source-target text for the Maxwell library.
 
         Args:
             dataset (data.Dataset): dataset for generating expert vocabulary.

--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -146,8 +146,8 @@ class HardAttentionRNNModel(rnn.RNNModel):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Decodes a sequence given the encoded input.
 
-        Decodes until all sequences in a batch have reached <E> up to
-        a specified length depending on the `target` args.
+        Decodes until all sequences in a batch have reached END up to a
+        specified length depending on the `target` args.
 
         Args:
             encoder_out (torch.Tensor): batch of encoded input symbols

--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -97,7 +97,7 @@ class HardAttentionRNNModel(rnn.RNNModel):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Decodes a sequence given the encoded input.
 
-        Decodes until all sequences in a batch have reached [EOS] up to
+        Decodes until all sequences in a batch have reached <E> up to
         length of `target` args.
 
         Args:
@@ -133,6 +133,24 @@ class HardAttentionRNNModel(rnn.RNNModel):
             all_transition_probs.append(transition_probs)
         return torch.stack(all_log_probs), torch.stack(all_transition_probs)
 
+    def beam_decode(
+        self,
+        encoder_out: torch.Tensor,
+        mask: torch.Tensor,
+    ):
+        """Overrides incompatible implementation inherited from RNNModel.
+
+        Args:
+            encoder_out (torch.Tensor).
+            encoder_mask (torch.Tensor).
+
+        Raises:
+            NotImplementedError: beam search not implemented.
+        """
+        raise NotImplementedError(
+            f"Beam search not implemented for {self.name} model"
+        )
+
     def greedy_decode(
         self,
         encoder_out: torch.Tensor,
@@ -140,7 +158,7 @@ class HardAttentionRNNModel(rnn.RNNModel):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Decodes a sequence given the encoded input.
 
-        Decodes until all sequences in a batch have reached [EOS] up to
+        Decodes until all sequences in a batch have reached <E> up to
         a specified length depending on the `target` args.
 
         Args:
@@ -309,9 +327,7 @@ class HardAttentionRNNModel(rnn.RNNModel):
             )
         elif self.beam_width > 1:
             # Will raise a NotImplementedError.
-            output = self.beam_decode(
-                encoder_out, batch.source.mask, beam_width
-            )
+            return self.beam_decode(encoder_out, batch.source.mask)
         else:
             return self.greedy_decode(encoder_out, batch.source.mask)
 

--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -97,8 +97,8 @@ class HardAttentionRNNModel(rnn.RNNModel):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Decodes a sequence given the encoded input.
 
-        Decodes until all sequences in a batch have reached <E> up to
-        length of `target` args.
+        Decodes until all sequences in a batch have reached END up to length of
+        `target` args.
 
         Args:
             encoder_out (torch.Tensor): batch of encoded input symbols
@@ -133,20 +133,8 @@ class HardAttentionRNNModel(rnn.RNNModel):
             all_transition_probs.append(transition_probs)
         return torch.stack(all_log_probs), torch.stack(all_transition_probs)
 
-    def beam_decode(
-        self,
-        encoder_out: torch.Tensor,
-        mask: torch.Tensor,
-    ):
-        """Overrides incompatible implementation inherited from RNNModel.
-
-        Args:
-            encoder_out (torch.Tensor).
-            encoder_mask (torch.Tensor).
-
-        Raises:
-            NotImplementedError: beam search not implemented.
-        """
+    def beam_decode(self, *args, **kwargs):
+        """Overrides incompatible implementation inherited from RNNModel."""
         raise NotImplementedError(
             f"Beam search not implemented for {self.name} model"
         )

--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -278,7 +278,7 @@ class RNNModel(base.BaseModel):
 
     @staticmethod
     def add_argparse_args(parser: argparse.ArgumentParser) -> None:
-        """Adds LSTM configuration options to the argument parser.
+        """Adds RNN configuration options to the argument parser.
 
         Args:
             parser (argparse.ArgumentParser).

--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -170,8 +170,8 @@ class RNNModel(base.BaseModel):
     ) -> torch.Tensor:
         """Decodes a sequence given the encoded input.
 
-        Decodes until all sequences in a batch have reached <E> up to
-        a specified length depending on the `target` args.
+        Decodes until all sequences in a batch have reached END up to a
+        specified length depending on the `target` args.
 
         Args:
             encoder_out (torch.Tensor): batch of encoded input symbols.

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -96,13 +96,13 @@ class TransducerRNNModel(rnn.RNNModel):
             last_hiddens = self.init_hiddens(source_mask.shape[0])
         if self.beam_width > 1:
             # Will raise a NotImplementedError.
-            prediction = self.beam_decode(
+            return self.beam_decode(
                 encoder_out=encoded,
                 mask=batch.source.mask,
                 beam_width=self.beam_width,
             )
         else:
-            prediction, loss = self.decode(
+            return self.greedy_decode(
                 encoded,
                 last_hiddens,
                 source_padded,
@@ -113,9 +113,14 @@ class TransducerRNNModel(rnn.RNNModel):
                 target=batch.target.padded if batch.target else None,
                 target_mask=batch.target.mask if batch.target else None,
             )
-        return prediction, loss
 
-    def decode(
+    def beam_decode(self, *args, **kwargs):
+        """Overrides incompatible implementation inherited from RNNModel."""
+        raise NotImplementedError(
+            f"Beam search not implemented for {self.name} model"
+        )
+
+    def greedy_decode(
         self,
         encoder_out: torch.Tensor,
         last_hiddens: Tuple[torch.Tensor, torch.Tensor],

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -560,9 +560,9 @@ class TransducerRNNModel(rnn.RNNModel):
             pred.extend(pad)
             predictions[i] = torch.tensor(pred, dtype=torch.int)
         predictions = torch.stack(predictions)
-        # This turns all symbols after the first EOS into PAD so prediction
+        # This turns all symbols after the first END into PAD so prediction
         # tensors match gold tensors.
-        return util.pad_tensor_after_eos(predictions)
+        return util.pad_tensor_after_end(predictions)
 
     def on_train_epoch_start(self) -> None:
         """Scheduler for oracle."""

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -51,69 +51,6 @@ class TransducerRNNModel(rnn.RNNModel):
         self.substitutions = self.actions.substitutions
         self.insertions = self.actions.insertions
 
-    def forward(
-        self,
-        batch: data.PaddedBatch,
-    ) -> Tuple[List[List[int]], torch.Tensor]:
-        """Runs the encoder-decoder model.
-
-        Args:
-            batch (data.PaddedBatch).
-
-        Returns:
-            Tuple[List[List[int]], torch.Tensor]: encoded prediction values
-                and loss tensor; due to transducer setup, prediction is
-                performed during training, so these are returned.
-        """
-        encoder_out = self.source_encoder(batch.source)
-        encoded = encoder_out.output[:, 1:, :]  # Ignores start symbol.
-        source_padded = batch.source.padded[:, 1:]
-        source_mask = batch.source.mask[:, 1:]
-        # Start of decoding.
-        if self.has_features_encoder:
-            features_encoder_out = self.features_encoder(batch.features)
-            features_encoded = features_encoder_out.output
-            if features_encoder_out.has_hiddens:
-                h_features, c_features = features_encoder_out.hiddens
-                h_features = h_features.mean(dim=0, keepdim=True).expand(
-                    self.decoder_layers, -1, -1
-                )
-                c_features = c_features.mean(dim=0, keepdim=True).expand(
-                    self.decoder_layers, -1, -1
-                )
-                last_hiddens = h_features, c_features
-            else:
-                last_hiddens = self.init_hiddens(source_mask.shape[0])
-            features_encoded = features_encoded.mean(dim=1, keepdim=True)
-            encoded = torch.cat(
-                (
-                    encoded,
-                    features_encoded.expand(-1, encoded.shape[1], -1),
-                ),
-                dim=2,
-            )
-        else:
-            last_hiddens = self.init_hiddens(source_mask.shape[0])
-        if self.beam_width > 1:
-            # Will raise a NotImplementedError.
-            return self.beam_decode(
-                encoder_out=encoded,
-                mask=batch.source.mask,
-                beam_width=self.beam_width,
-            )
-        else:
-            return self.greedy_decode(
-                encoded,
-                last_hiddens,
-                source_padded,
-                source_mask,
-                teacher_forcing=(
-                    self.teacher_forcing if self.training else False
-                ),
-                target=batch.target.padded if batch.target else None,
-                target_mask=batch.target.mask if batch.target else None,
-            )
-
     def beam_decode(self, *args, **kwargs):
         """Overrides incompatible implementation inherited from RNNModel."""
         raise NotImplementedError(
@@ -546,10 +483,10 @@ class TransducerRNNModel(rnn.RNNModel):
         val_eval_items_dict.update({"val_loss": loss})
         return val_eval_items_dict
 
-    def predict_step(self, batch: Tuple[torch.tensor], batch_idx: int) -> Dict:
-        predictions, _ = self.forward(
-            batch,
-        )
+    def predict_step(
+        self, batch: data.PaddedBatch, batch_idx: int
+    ) -> torch.Tensor:
+        predictions, _ = self(batch)
         # Evaluation requires prediction tensor.
         return self.convert_predictions(predictions)
 
@@ -590,9 +527,6 @@ class TransducerRNNModel(rnn.RNNModel):
     @property
     def name(self) -> str:
         raise NotImplementedError
-
-
-# TODO: Implement beam decoding.
 
 
 class TransducerGRUModel(TransducerRNNModel, rnn.GRUModel):
@@ -644,16 +578,31 @@ class TransducerGRUModel(TransducerRNNModel, rnn.GRUModel):
             )
         else:
             last_hiddens = self.init_hiddens(source_mask.shape[0])
-        prediction, loss = self.decode(
-            encoded,
-            last_hiddens,
-            source_padded,
-            source_mask,
-            teacher_forcing=(self.teacher_forcing if self.training else False),
-            target=batch.target.padded if batch.target else None,
-            target_mask=batch.target.mask if batch.target else None,
-        )
-        return prediction, loss
+        if self.beam_width > 1:
+            # Will raise a NotImplementedError.
+            return self.beam_decode(
+                encoded,
+                last_hiddens,
+                source_padded,
+                source_mask,
+                teacher_forcing=(
+                    self.teacher_forcing if self.training else False
+                ),
+                target=batch.target.padded if batch.target else None,
+                target_mask=batch.target.mask if batch.target else None,
+            )
+        else:
+            return self.greedy_decode(
+                encoded,
+                last_hiddens,
+                source_padded,
+                source_mask,
+                teacher_forcing=(
+                    self.teacher_forcing if self.training else False
+                ),
+                target=batch.target.padded if batch.target else None,
+                target_mask=batch.target.mask if batch.target else None,
+            )
 
     def get_decoder(self) -> modules.GRUDecoder:
         return modules.GRUDecoder(
@@ -731,16 +680,31 @@ class TransducerLSTMModel(TransducerRNNModel):
             )
         else:
             last_hiddens = self.init_hiddens(source_mask.shape[0])
-        prediction, loss = self.decode(
-            encoded,
-            last_hiddens,
-            source_padded,
-            source_mask,
-            teacher_forcing=(self.teacher_forcing if self.training else False),
-            target=batch.target.padded if batch.target else None,
-            target_mask=batch.target.mask if batch.target else None,
-        )
-        return prediction, loss
+        if self.beam_width > 1:
+            # Will raise a NotImplementedError.
+            return self.beam_decode(
+                encoded,
+                last_hiddens,
+                source_padded,
+                source_mask,
+                teacher_forcing=(
+                    self.teacher_forcing if self.training else False
+                ),
+                target=batch.target.padded if batch.target else None,
+                target_mask=batch.target.mask if batch.target else None,
+            )
+        else:
+            return self.greedy_decode(
+                encoded,
+                last_hiddens,
+                source_padded,
+                source_mask,
+                teacher_forcing=(
+                    self.teacher_forcing if self.training else False
+                ),
+                target=batch.target.padded if batch.target else None,
+                target_mask=batch.target.mask if batch.target else None,
+            )
 
     def init_hiddens(
         self, batch_size: int

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -85,7 +85,7 @@ class TransformerModel(base.BaseModel):
             source_mask (torch.Tensor): mask for the encoded source tokens.
             targets (torch.Tensor, optional): the optional target tokens,
                 which is only used for early stopping during validation
-                if the decoder has predicted <E> for every sequence in
+                if the decoder has predicted END for every sequence in
                 the batch.
 
         Returns:

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -67,7 +67,7 @@ class TransformerModel(base.BaseModel):
             source_attention_heads=self.source_attention_heads,
         )
 
-    def _decode_greedy(
+    def greedy_decode(
         self,
         encoder_hidden: torch.Tensor,
         source_mask: torch.Tensor,
@@ -172,13 +172,13 @@ class TransformerModel(base.BaseModel):
             if self.beam_width > 1:
                 # Will raise a NotImplementedError.
                 output = self.beam_decode(
-                    encoder_out=encoder_output,
-                    mask=batch.source.mask,
-                    beam_width=self.beam_width,
+                    encoder_output,
+                    batch.source.mask,
+                    self.beam_width,
                 )
             else:
                 # -> B x seq_len x output_size.
-                output = self._decode_greedy(
+                output = self.greedy_decode(
                     encoder_output,
                     batch.source.mask,
                     batch.target.padded if batch.target else None,

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -67,6 +67,11 @@ class TransformerModel(base.BaseModel):
             source_attention_heads=self.source_attention_heads,
         )
 
+    def beam_decode(self, *args, **kwargs):
+        raise NotImplementedError(
+            f"Beam search not implemented for {self.name} model"
+        )
+
     def greedy_decode(
         self,
         encoder_hidden: torch.Tensor,
@@ -166,24 +171,23 @@ class TransformerModel(base.BaseModel):
                 target_mask,
             ).output
             logits = self.classifier(decoder_output)
-            output = logits[:, :-1, :]  # Ignore END.
+            return logits[:, :-1, :]  # Ignores END.
         else:
             encoder_output = self.source_encoder(batch.source).output
             if self.beam_width > 1:
                 # Will raise a NotImplementedError.
-                output = self.beam_decode(
+                return self.beam_decode(
                     encoder_output,
                     batch.source.mask,
                     self.beam_width,
                 )
             else:
                 # -> B x seq_len x output_size.
-                output = self.greedy_decode(
+                return self.greedy_decode(
                     encoder_output,
                     batch.source.mask,
                     batch.target.padded if batch.target else None,
                 )
-        return output
 
     @property
     def name(self) -> str:

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -157,7 +157,7 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
     data.add_argparse_args(parser)
     # Architecture arguments; the architecture-specific ones are not needed.
     models.add_argparse_args(parser)
-    models.BaseEncoderDecoder.add_predict_argparse_args(parser)
+    models.BaseModel.add_predict_argparse_args(parser)
     # Among the things this adds, the following are likely to be useful:
     # --accelerator ("gpu" for GPU)
     # --devices (for multiple device support)

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -3,7 +3,6 @@
 import argparse
 import csv
 import itertools
-import os
 
 import lightning
 
@@ -80,17 +79,6 @@ def get_model_from_argparse_args(
     return model_cls.load_from_checkpoint(args.checkpoint, **kwargs)
 
 
-def _mkdir(output: str) -> None:
-    """Creates directory for output file if necessary.
-
-    Args:
-        output (str): output to output file.
-    """
-    dirname = os.path.dirname(output)
-    if dirname:
-        os.makedirs(dirname, exist_ok=True)
-
-
 def predict(
     trainer: lightning.Trainer,
     model: models.BaseModel,
@@ -106,7 +94,7 @@ def predict(
          output (str).
     """
     util.log_info(f"Writing to {output}")
-    _mkdir(output)
+    util.mkpath(output)
     loader = datamodule.predict_dataloader()
     with open(output, "w", encoding=defaults.ENCODING) as sink:
         if model.beam_width > 1:

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -102,7 +102,6 @@ def predict(
             # Beam search.
             tsv_writer = csv.writer(sink, delimiter="\t")
             for predictions, scores in trainer.predict(model, loader):
-                predictions = util.pad_tensor_after_eos(predictions)
                 # TODO: beam search requires singleton batches and this
                 # assumes that. Revise if that restriction is ever lifted.
                 targets = [
@@ -121,17 +120,6 @@ def predict(
                 for target in predictions:
                     symbols = mapper.decode_target(target)
                     print(parser.target_string(symbols), file=sink)
-
-
-def _mkdir(output: str) -> None:
-    """Creates directory for output file if necessary.
-
-    Args:
-        output (str): output to output file.
-    """
-    dirname = os.path.dirname(output)
-    if dirname:
-        os.makedirs(dirname, exist_ok=True)
 
 
 def add_argparse_args(parser: argparse.ArgumentParser) -> None:

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -114,12 +114,10 @@ def predict(
                 tsv_writer.writerow(row)
         else:
             # Greedy search.
-            for predictions, _ in trainer.predict(model, loader):
-                predictions = util.pad_tensor_after_eos(predictions)
-                # Unpacks each element in the batch.
-                for target in predictions:
-                    symbols = mapper.decode_target(target)
-                    print(parser.target_string(symbols), file=sink)
+            for predictions in trainer.predict(model, loader):
+                predictions = util.pad_tensor_after_end(predictions)
+                for prediction in loader.dataset.decode_target(predictions):
+                    print(prediction, file=sink)
 
 
 def add_argparse_args(parser: argparse.ArgumentParser) -> None:

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -36,9 +36,13 @@ def get_datamodule_from_argparse_args(
         data.DataModule.
     """
     separate_features = args.features_col != 0 and args.arch in [
-        "pointer_generator_rnn",
+        "hard_attention_gru",
+        "hard_attention_lstm",
+        "pointer_generator_gru",
+        "pointer_generator_lstm",
         "pointer_generator_transformer",
-        "transducer",
+        "transducer_grm",
+        "transducer_lstm",
     ]
     index = data.Index.read(args.model_dir)
     return data.DataModule(

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -40,7 +40,7 @@ def get_datamodule_from_argparse_args(
         "pointer_generator_transformer",
         "transducer",
     ]
-    index = data.Index.read(args.model_dir, args.experiment)
+    index = data.Index.read(args.model_dir)
     return data.DataModule(
         predict=args.predict,
         batch_size=args.batch_size,
@@ -139,9 +139,6 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         "--model_dir",
         required=True,
         help="Path to output model directory.",
-    )
-    parser.add_argument(
-        "--experiment", required=True, help="Name of experiment."
     )
     parser.add_argument(
         "--predict",

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -43,8 +43,8 @@ def get_datamodule_from_argparse_args(
         "transducer_grm",
         "transducer_lstm",
     ]
-    index = data.Index.read(args.model_dir)
     return data.DataModule(
+        model_dir=args.model_dir,
         predict=args.predict,
         batch_size=args.batch_size,
         source_col=args.source_col,
@@ -56,7 +56,6 @@ def get_datamodule_from_argparse_args(
         separate_features=separate_features,
         max_source_length=args.max_source_length,
         max_target_length=args.max_target_length,
-        index=index,
     )
 
 
@@ -96,23 +95,43 @@ def predict(
     util.log_info(f"Writing to {output}")
     util.mkpath(output)
     loader = datamodule.predict_dataloader()
+    parser = datamodule.parser
+    mapper = data.Mapper(datamodule.index)
     with open(output, "w", encoding=defaults.ENCODING) as sink:
         if model.beam_width > 1:
             # Beam search.
             tsv_writer = csv.writer(sink, delimiter="\t")
             for predictions, scores in trainer.predict(model, loader):
                 predictions = util.pad_tensor_after_eos(predictions)
-                decoded_predictions = loader.dataset.decode_target(predictions)
-                row = itertools.chain(
-                    *zip(decoded_predictions, scores.tolist())
+                # TODO: beam search requires singleton batches and this
+                # assumes that. Revise if that restriction is ever lifted.
+                targets = [
+                    parser.target_string(mapper.decode_target(target))
+                    for target in predictions
+                ]
+                row = itertools.chain.from_iterable(
+                    zip(targets, scores.tolist())
                 )
                 tsv_writer.writerow(row)
         else:
             # Greedy search.
             for predictions, _ in trainer.predict(model, loader):
                 predictions = util.pad_tensor_after_eos(predictions)
-                for prediction in loader.dataset.decode_target(predictions):
-                    print(prediction, file=sink)
+                # Unpacks each element in the batch.
+                for target in predictions:
+                    symbols = mapper.decode_target(target)
+                    print(parser.target_string(symbols), file=sink)
+
+
+def _mkdir(output: str) -> None:
+    """Creates directory for output file if necessary.
+
+    Args:
+        output (str): output to output file.
+    """
+    dirname = os.path.dirname(output)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
 
 
 def add_argparse_args(parser: argparse.ArgumentParser) -> None:

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -206,9 +206,7 @@ def get_model_from_argparse_args(
     expert = None
     if args.arch in ["transducer_gru", "transducer_lstm"]:
         sed_params_paths = (
-            args.sed_params
-            if args.sed_params
-            else f"{args.model_dir}/sed.pkl"
+            args.sed_params if args.sed_params else f"{args.model_dir}/sed.pkl"
         )
         expert = models.expert.get_expert(
             datamodule.train_dataloader().dataset,

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -149,9 +149,9 @@ def get_datamodule_from_argparse_args(
         "transducer_lstm",
     ]
     datamodule = data.DataModule(
+        model_dir=args.model_dir,
         train=args.train,
         val=args.val,
-        batch_size=args.batch_size,
         source_col=args.source_col,
         features_col=args.features_col,
         target_col=args.target_col,
@@ -159,13 +159,13 @@ def get_datamodule_from_argparse_args(
         features_sep=args.features_sep,
         target_sep=args.target_sep,
         separate_features=separate_features,
+        tie_embeddings=args.tie_embeddings,
+        batch_size=args.batch_size,
         max_source_length=args.max_source_length,
         max_target_length=args.max_target_length,
-        tie_embeddings=args.tie_embeddings,
     )
     if not datamodule.has_target:
         raise Error("No target column specified")
-    datamodule.index.write(args.model_dir)
     datamodule.log_vocabularies()
     return datamodule
 
@@ -210,6 +210,7 @@ def get_model_from_argparse_args(
         )
         expert = models.expert.get_expert(
             datamodule.train_dataloader().dataset,
+            datamodule.index,
             epochs=args.oracle_em_epochs,
             oracle_factor=args.oracle_factor,
             sed_params_path=sed_params_paths,

--- a/yoyodyne/util.py
+++ b/yoyodyne/util.py
@@ -2,13 +2,13 @@
 
 import argparse
 import sys
+import os
+
 from typing import Any, Optional
 
 import torch
 
 from . import special
-
-# Argument parsing.
 
 
 class UniqueAddAction(argparse.Action):
@@ -24,7 +24,39 @@ class UniqueAddAction(argparse.Action):
         getattr(namespace, self.dest).add(values)
 
 
-# Tensor manipulation
+def log_info(msg: str) -> None:
+    """Logs msg to sys.stderr.
+
+    We can additionally consider logging to a file, or getting a handle to the
+    PL logger.
+
+    Args:
+        msg (str): the message to log.
+    """
+    print(msg, file=sys.stderr)
+
+
+def log_arguments(args: argparse.Namespace) -> None:
+    """Logs non-null arguments via log_info.
+
+    Args:
+        args (argparse.Namespace).
+    """
+    log_info("Arguments:")
+    for arg, val in vars(args).items():
+        if val is None:
+            continue
+        log_info(f"\t{arg}: {val!r}")
+
+
+def mkpath(path: str) -> None:
+    """Creates subdirectories for a path if they do not already exist.
+
+    Args:
+        path (str).
+    """
+    dirname = os.path.dirname(os.path.abspath(path))
+    os.makedirs(dirname, exist_ok=True)
 
 
 def pad_tensor_after_eos(
@@ -73,29 +105,3 @@ def pad_tensor_after_eos(
     return predictions
 
 
-# Logging.
-
-
-def log_info(msg: str) -> None:
-    """Logs msg to sys.stderr.
-
-    We can additionally consider logging to a file, or getting a handle to the
-    PL logger.
-
-    Args:
-        msg (str): the message to log.
-    """
-    print(msg, file=sys.stderr)
-
-
-def log_arguments(args: argparse.Namespace) -> None:
-    """Logs non-null arguments via log_info.
-
-    Args:
-        args (argparse.Namespace).
-    """
-    log_info("Arguments:")
-    for arg, val in vars(args).items():
-        if val is None:
-            continue
-        log_info(f"\t{arg}: {val!r}")

--- a/yoyodyne/util.py
+++ b/yoyodyne/util.py
@@ -1,8 +1,12 @@
 """Utilities."""
 
 import argparse
-import sys
 import os
+import sys
+<<<<<<< HEAD
+import os
+=======
+>>>>>>> 65e28c0 (Standardizes name: "END" not "EOS".)
 
 from typing import Any, Optional
 
@@ -59,14 +63,10 @@ def mkpath(path: str) -> None:
     os.makedirs(dirname, exist_ok=True)
 
 
-def pad_tensor_after_eos(
+def pad_tensor_after_end(
     predictions: torch.Tensor,
 ) -> torch.Tensor:
-    """Replaces everything after an EOS token with PADs.
-
-    Cuts off tensors at the first END_IDX, and replaces the rest of the
-    predictions with PAD_IDX, as these can be erroneously decoded while the
-    rest of the batch is finishing decoding.
+    """Replaces everything after an END token with PADs.
 
     Args:
         predictions (torch.Tensor): prediction tensor.
@@ -78,22 +78,22 @@ def pad_tensor_after_eos(
     if predictions.size(0) == 1:
         return predictions
     for i, prediction in enumerate(predictions):
-        # Gets first instance of EOS.
-        eos = (prediction == special.END_IDX).nonzero(as_tuple=False)
-        if len(eos) > 0 and eos[0].item() < len(prediction):
-            # If an EOS was decoded and it is not the last one in the
+        # Gets first instance of END.
+        end = (prediction == special.END_IDX).nonzero(as_tuple=False)
+        if len(end) > 0 and end[0].item() < len(prediction):
+            # If an END was decoded and it is not the last one in the
             # sequence.
-            eos = eos[0]
+            end = end[0]
         else:
             # Leaves predictions[i] alone.
             continue
-        # Hack in case the first prediction is EOS. In this case
+        # Hack in case the first prediction is END. In this case
         # torch.split will result in an error, so we change these 0's to
-        # 1's, which will make the entire sequence EOS as intended.
-        eos[eos == 0] = 1
-        symbols, *_ = torch.split(prediction, eos)
+        # 1's, which will make the entire sequence END as intended.
+        end[end == 0] = 1
+        symbols, *_ = torch.split(prediction, end)
         # Replaces everything after with PAD, to replace erroneous decoding
-        # While waiting on the entire batch to finish.
+        # while waiting on the entire batch to finish.
         pads = (
             torch.ones(len(prediction) - len(symbols), device=symbols.device)
             * special.PAD_IDX
@@ -103,5 +103,3 @@ def pad_tensor_after_eos(
         with torch.inference_mode():
             predictions[i] = torch.cat((symbols, pads))
     return predictions
-
-


### PR DESCRIPTION
Closes #60.
Closes #218.

LightningCLI removes our need to create separate training and prediction CLI programs, moving nearly all of that logic into the base model.

This commit in particular sets the stage:

* Updates dependencies.
* Increments minor version number.
* Creates an empty `cli.py` where the CLI-speific logic will live.