### PR TITLE
Removes separate "experiment" subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ provide any symbols of the form `<...>`, `[...]`, or `{...}`.
 Checkpointing is handled by
 [Lightning](https://pytorch-lightning.readthedocs.io/en/stable/common/checkpointing_basic.html).
 The path for model information, including checkpoints, is specified by
-`--model_dir` such that we build the path `model_dir/version_n`,
-where each run of an experiment with the same `model_dir` is namespaced with a
-new version number. A version stores all of the following:
+`--model_dir` such that we build the path `model_dir/version_n`, where each run
+of an experiment with the same `model_dir` is namespaced with a new version
+number. A version stores all of the following:
 
 -   the index (`model_dir/index.pkl`),
 -   the hyperparameters (`model_dir/lightning_logs/version_n/hparams.yaml`),
@@ -288,7 +288,9 @@ A non-exhaustive list includes:
 -   Seeding:
     -   `--seed`
 -   [Weights & Biases](https://wandb.ai/site):
-    -   `--log_wandb` (default: `False`): enables Weights & Biases tracking
+    -   `--log_wandb` (default: `False`): enables Weights & Biases tracking; the
+        "project" name can be specified using the environmental variable
+        `$WANDB_PROJECT`.
 
 Additional training options are discussed below.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Training is performed by the [`yoyodyne-train`](yoyodyne/train.py) script. One
 must specify the following required arguments:
 
 -   `--model_dir`: path for model metadata and checkpoints
--   `--experiment`: name of experiment (pick something unique)
 -   `--train`: path to TSV file containing training data
 -   `--val`: path to TSV file containing validation data
 
@@ -161,13 +160,15 @@ provide any symbols of the form `<...>`, `[...]`, or `{...}`.
 
 Checkpointing is handled by
 [Lightning](https://pytorch-lightning.readthedocs.io/en/stable/common/checkpointing_basic.html).
-The path for model information, including checkpoints, is specified by a
-combination of `--model_dir` and `--experiment`, such that we build the path
-`model_dir/experiment/version_n`, where each run of an experiment with the same
-`model_dir` and `experiment` is namespaced with a new version number. A version
-stores everything needed to reload the model, including the hyperparameters
-(`model_dir/experiment_name/version_n/hparams.yaml`) and the checkpoints
-directory (`model_dir/experiment_name/version_n/checkpoints`).
+The path for model information, including checkpoints, is specified by
+`--model_dir` such that we build the path `model_dir/version_n`,
+where each run of an experiment with the same `model_dir` is namespaced with a
+new version number. A version stores all of the following:
+
+-   the index (`model_dir/index.pkl`),
+-   the hyperparameters (`model_dir/lightning_logs/version_n/hparams.yaml`),
+-   the metrics (`model_dir/lightning_logs/version_n/metrics.csv`), and
+-   the checkpoints (`model_dir/lightning_logs/version_n/checkpoints`).
 
 By default, each run initializes a new model from scratch, unless the
 `--train_from` argument is specified. To continue training from a specific

--- a/yoyodyne/data/datamodules.py
+++ b/yoyodyne/data/datamodules.py
@@ -128,9 +128,9 @@ class DataModule(lightning.LightningDataModule):
                 f"{self.pprint(self.index.target_vocabulary)}"
             )
 
-    def write_index(self, model_dir: str, experiment: str) -> None:
+    def write_index(self, model_dir: str) -> None:
         """Writes the index."""
-        self.index.write(model_dir, experiment)
+        self.index.write(model_dir)
 
     @property
     def has_features(self) -> bool:

--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -87,18 +87,17 @@ class Index:
     # Serialization support.
 
     @classmethod
-    def read(cls, model_dir: str, experiment: str) -> "Index":
+    def read(cls, model_dir: str) -> "Index":
         """Loads index.
 
         Args:
             model_dir (str).
-            experiment (str).
 
         Returns:
             Index.
         """
         index = cls.__new__(cls)
-        path = index.index_path(model_dir, experiment)
+        path = index.index_path(model_dir)
         with open(path, "rb") as source:
             dictionary = pickle.load(source)
         for key, value in dictionary.items():
@@ -106,26 +105,24 @@ class Index:
         return index
 
     @staticmethod
-    def index_path(model_dir: str, experiment: str) -> str:
+    def index_path(model_dir: str) -> str:
         """Computes path for the index file.
 
         Args:
             model_dir (str).
-            experiment (str).
 
         Returns:
             str.
         """
-        return f"{model_dir}/{experiment}/index.pkl"
+        return f"{model_dir}/index.pkl"
 
-    def write(self, model_dir: str, experiment: str) -> None:
+    def write(self, model_dir: str) -> None:
         """Writes index.
 
         Args:
             model_dir (str).
-            experiment (str).
         """
-        path = self.index_path(model_dir, experiment)
+        path = self.index_path(model_dir)
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "wb") as sink:
             pickle.dump(vars(self), sink)

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -40,7 +40,7 @@ def get_datamodule_from_argparse_args(
         "pointer_generator_transformer",
         "transducer",
     ]
-    index = data.Index.read(args.model_dir, args.experiment)
+    index = data.Index.read(args.model_dir)
     return data.DataModule(
         predict=args.predict,
         batch_size=args.batch_size,
@@ -139,9 +139,6 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         "--model_dir",
         required=True,
         help="Path to output model directory.",
-    )
-    parser.add_argument(
-        "--experiment", required=True, help="Name of experiment."
     )
     parser.add_argument(
         "--predict",

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -206,9 +206,7 @@ def get_model_from_argparse_args(
     expert = None
     if args.arch in ["transducer_gru", "transducer_lstm"]:
         sed_params_paths = (
-            args.sed_params
-            if args.sed_params
-            else f"{args.model_dir}/sed.pkl"
+            args.sed_params if args.sed_params else f"{args.model_dir}/sed.pkl"
         )
         expert = models.expert.get_expert(
             datamodule.train_dataloader().dataset,


### PR DESCRIPTION
This adds an extra flag to every command and for what? If you want to keep model directories separate for different experiments in a way that goes beyond already done with the automated versioning, you can just append a subdirectory name to `--model_dir`, e.g., using `--model_dir models/foo` instead of `--model_dir models --experiment foo`.

The README is updated to reflect.