### PR TITLE
Use future annotations

### DIFF
--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -1,5 +1,7 @@
 """Symbol index."""
 
+from __future__ import annotations
+
 import os
 import pickle
 from typing import Dict, Iterable, List, Optional
@@ -87,7 +89,7 @@ class Index:
     # Serialization support.
 
     @classmethod
-    def read(cls, model_dir: str, experiment: str) -> "Index":
+    def read(cls, model_dir: str, experiment: str) -> Index:
         """Loads index.
 
         Args:


### PR DESCRIPTION
There is just one location where this is useful.

For context, see [PEP 563](https://peps.python.org/pep-0563/). 

Note that this is backwards compatible all the way back to Python 3.7 (which we don't even support) and thus harmless.