### PR TITLE
Fixes prediction across all architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ One must specify the following required arguments:
 
 -   `--arch`: architecture, matching the one used for training
 -   `--model_dir`: path for model metadata
--   `--experiment`: name of experiment
 -   `--checkpoint`: path to checkpoint
 -   `--predict`: path to file containing data to be predicted
 -   `--output`: path for predictions

--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -89,7 +89,7 @@ class Index:
     # Serialization support.
 
     @classmethod
-    def read(cls, model_dir: str, experiment: str) -> Index:
+    def read(cls, model_dir: str) -> Index:
         """Loads index.
 
         Args:

--- a/yoyodyne/evaluators.py
+++ b/yoyodyne/evaluators.py
@@ -136,7 +136,7 @@ class AccuracyEvaluator(Evaluator):
         Returns:
             torch.Tensor: finalized predictions.
         """
-        return util.pad_tensor_after_eos(predictions)
+        return util.pad_tensor_after_end(predictions)
 
     def finalize_golds(
         self,
@@ -197,8 +197,8 @@ class SEREvaluator(Evaluator):
     ) -> List[torch.Tensor]:
         """Finalizes each tensor.
 
-        Truncates at EOS for each prediction and returns a List of predictions.
-        This does basically the same as util.pad_after_eos, but does not
+        Truncates at END for each prediction and returns a List of predictions.
+        This does basically the same as util.pad_after_end, but does not
         actually pad since we do not need to return a well-formed tensor.
 
         Args:
@@ -212,21 +212,21 @@ class SEREvaluator(Evaluator):
             return [tensor]
         out = []
         for prediction in tensor:
-            # Gets first instance of EOS.
-            eos = (prediction == special.END_IDX).nonzero(as_tuple=False)
-            if len(eos) > 0 and eos[0].item() < len(prediction):
-                # If an EOS was decoded and it is not the last one in the
+            # Gets first instance of END.
+            end = (prediction == special.END_IDX).nonzero(as_tuple=False)
+            if len(end) > 0 and end[0].item() < len(prediction):
+                # If an END was decoded and it is not the last one in the
                 # sequence.
-                eos = eos[0]
+                end = end[0]
             else:
                 # Leaves tensor[i] alone.
                 out.append(prediction)
                 continue
-            # Hack in case the first prediction is EOS. In this case
+            # Hack in case the first prediction is END. In this case
             # torch.split will result in an error, so we change these 0's to
-            # 1's, which will make the entire sequence EOS as intended.
-            eos[eos == 0] = 1
-            symbols, *_ = torch.split(prediction, eos)
+            # 1's, which will make the entire sequence END as intended.
+            end[end == 0] = 1
+            symbols, *_ = torch.split(prediction, end)
             out.append(symbols)
         return out
 

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -191,11 +191,7 @@ class BaseModel(lightning.LightningModule):
                 hypotheses to return.
 
         Raises:
-            NotImplementedError: This method needs to be overridden.
-
-        Returns:
-            Tuple[torch.Tensor, torch.Tensor]: the predictions tensor and the
-                log-likelihood of each prediction.
+            NotImplementedError: beam search not implemented.
         """
         raise NotImplementedError(
             f"Beam search not implemented for {self.name} model"

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -180,15 +180,12 @@ class BaseModel(lightning.LightningModule):
         self,
         encoder_out: torch.Tensor,
         mask: torch.Tensor,
-        beam_width: int,
     ):
         """Method interface for beam search.
 
         Args:
-            encoder_out (torch.Tensor): encoded inputs.
+            encoder_out (torch.Tensor).
             encoder_mask (torch.Tensor).
-            beam_width (int): size of the beam; also determines the number of
-                hypotheses to return.
 
         Raises:
             NotImplementedError: beam search not implemented.

--- a/yoyodyne/models/expert.py
+++ b/yoyodyne/models/expert.py
@@ -456,7 +456,7 @@ def get_expert(
     ) -> Iterator[Tuple[List[int], List[int]]]:
         """Helper function to manage data encoding for SED."
 
-        We want encodings without BOS or EOS tokens. This
+        We want encodings without BOS or END tokens. This
         encodes only raw source-target text for the Maxwell library.
 
         Args:

--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -97,7 +97,7 @@ class HardAttentionRNNModel(rnn.RNNModel):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Decodes a sequence given the encoded input.
 
-        Decodes until all sequences in a batch have reached [EOS] up to
+        Decodes until all sequences in a batch have reached <E> up to
         length of `target` args.
 
         Args:
@@ -133,6 +133,24 @@ class HardAttentionRNNModel(rnn.RNNModel):
             all_transition_probs.append(transition_probs)
         return torch.stack(all_log_probs), torch.stack(all_transition_probs)
 
+    def beam_decode(
+        self,
+        encoder_out: torch.Tensor,
+        mask: torch.Tensor,
+    ):
+        """Overrides incompatible implementation inherited from RNNModel.
+
+        Args:
+            encoder_out (torch.Tensor).
+            encoder_mask (torch.Tensor).
+
+        Raises:
+            NotImplementedError: beam search not implemented.
+        """
+        raise NotImplementedError(
+            f"Beam search not implemented for {self.name} model"
+        )
+
     def greedy_decode(
         self,
         encoder_out: torch.Tensor,
@@ -140,7 +158,7 @@ class HardAttentionRNNModel(rnn.RNNModel):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Decodes a sequence given the encoded input.
 
-        Decodes until all sequences in a batch have reached [EOS] up to
+        Decodes until all sequences in a batch have reached <E> up to
         a specified length depending on the `target` args.
 
         Args:
@@ -309,9 +327,7 @@ class HardAttentionRNNModel(rnn.RNNModel):
             )
         elif self.beam_width > 1:
             # Will raise a NotImplementedError.
-            output = self.beam_decode(
-                encoder_out, batch.source.mask, beam_width
-            )
+            return self.beam_decode(encoder_out, batch.source.mask)
         else:
             return self.greedy_decode(encoder_out, batch.source.mask)
 

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -560,9 +560,9 @@ class TransducerRNNModel(rnn.RNNModel):
             pred.extend(pad)
             predictions[i] = torch.tensor(pred, dtype=torch.int)
         predictions = torch.stack(predictions)
-        # This turns all symbols after the first EOS into PAD so prediction
+        # This turns all symbols after the first END into PAD so prediction
         # tensors match gold tensors.
-        return util.pad_tensor_after_eos(predictions)
+        return util.pad_tensor_after_end(predictions)
 
     def on_train_epoch_start(self) -> None:
         """Scheduler for oracle."""

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -67,7 +67,7 @@ class TransformerModel(base.BaseModel):
             source_attention_heads=self.source_attention_heads,
         )
 
-    def _decode_greedy(
+    def greedy_decode(
         self,
         encoder_hidden: torch.Tensor,
         source_mask: torch.Tensor,
@@ -172,13 +172,13 @@ class TransformerModel(base.BaseModel):
             if self.beam_width > 1:
                 # Will raise a NotImplementedError.
                 output = self.beam_decode(
-                    encoder_out=encoder_output,
-                    mask=batch.source.mask,
-                    beam_width=self.beam_width,
+                    encoder_output,
+                    batch.source.mask,
+                    self.beam_width,
                 )
             else:
                 # -> B x seq_len x output_size.
-                output = self._decode_greedy(
+                output = self.greedy_decode(
                     encoder_output,
                     batch.source.mask,
                     batch.target.padded if batch.target else None,

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -113,7 +113,7 @@ def predict(
             # Beam search.
             tsv_writer = csv.writer(sink, delimiter="\t")
             for predictions, scores in trainer.predict(model, loader):
-                predictions = util.pad_tensor_after_eos(predictions)
+                predictions = util.pad_tensor_after_end(predictions)
                 decoded_predictions = loader.dataset.decode_target(predictions)
                 row = itertools.chain(
                     *zip(decoded_predictions, scores.tolist())
@@ -121,8 +121,8 @@ def predict(
                 tsv_writer.writerow(row)
         else:
             # Greedy search.
-            for predictions, _ in trainer.predict(model, loader):
-                predictions = util.pad_tensor_after_eos(predictions)
+            for predictions, *_ in trainer.predict(model, loader):
+                predictions = util.pad_tensor_after_end(predictions)
                 for prediction in loader.dataset.decode_target(predictions):
                     print(prediction, file=sink)
 

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -36,9 +36,13 @@ def get_datamodule_from_argparse_args(
         data.DataModule.
     """
     separate_features = args.features_col != 0 and args.arch in [
-        "pointer_generator_rnn",
+        "hard_attention_gru",
+        "hard_attention_lstm",
+        "pointer_generator_gru",
+        "pointer_generator_lstm",
         "pointer_generator_transformer",
-        "transducer",
+        "transducer_grm",
+        "transducer_lstm",
     ]
     index = data.Index.read(args.model_dir)
     return data.DataModule(

--- a/yoyodyne/util.py
+++ b/yoyodyne/util.py
@@ -27,12 +27,12 @@ class UniqueAddAction(argparse.Action):
 # Tensor manipulation
 
 
-def pad_tensor_after_eos(
+def pad_tensor_after_end(
     predictions: torch.Tensor,
 ) -> torch.Tensor:
-    """Replaces everything after an EOS token with PADs.
+    """Replaces everything after an END token with PADs.
 
-    Cuts off tensors at the first END_IDX, and replaces the rest of the
+    Cuts off tensors at the first END, and replaces the rest of the
     predictions with PAD_IDX, as these can be erroneously decoded while the
     rest of the batch is finishing decoding.
 
@@ -46,20 +46,20 @@ def pad_tensor_after_eos(
     if predictions.size(0) == 1:
         return predictions
     for i, prediction in enumerate(predictions):
-        # Gets first instance of EOS.
-        eos = (prediction == special.END_IDX).nonzero(as_tuple=False)
-        if len(eos) > 0 and eos[0].item() < len(prediction):
-            # If an EOS was decoded and it is not the last one in the
+        # Gets first instance of END.
+        end = (prediction == special.END_IDX).nonzero(as_tuple=False)
+        if len(end) > 0 and end[0].item() < len(prediction):
+            # If an END was decoded and it is not the last one in the
             # sequence.
-            eos = eos[0]
+            end = end[0]
         else:
             # Leaves predictions[i] alone.
             continue
-        # Hack in case the first prediction is EOS. In this case
+        # Hack in case the first prediction is END. In this case
         # torch.split will result in an error, so we change these 0's to
-        # 1's, which will make the entire sequence EOS as intended.
-        eos[eos == 0] = 1
-        symbols, *_ = torch.split(prediction, eos)
+        # 1's, which will make the entire sequence END as intended.
+        end[end == 0] = 1
+        symbols, *_ = torch.split(prediction, end)
         # Replaces everything after with PAD, to replace erroneous decoding
         # While waiting on the entire batch to finish.
         pads = (


### PR DESCRIPTION
Two bugs found by testing prediction across all architectures:

* Hard attention models inherit the beam search implementation in `RNNModel`, but it's incompatible so it needs to be disabled. Failing to do this results in an inscrutable error instead of a `NotImplementedError`. This is fixed.
* The base model implementation of the prediction loop is made to have what seems like the obvious polymorphic return type which restores compatibility for hard attention. I suspect this is a minor regression introduced in #257.

Clean-ups done at the same time:

* Standardizes the name of the special symbol: it's called EOS at various points in the documentation but the code actually calls it `END` and its tag is `<E>`.
* Uses the names `beam_decode` and `greedy_decode` everywhere.