### PR TITLE
Cleanup to index writing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = ["examples*"]
 
 [project]
 name = "yoyodyne"
-version = "0.2.15"
+version = "0.2.16"
 description = "Small-vocabulary neural sequence-to-sequence models"
 readme = "README.md"
 requires-python = ">= 3.9"

--- a/yoyodyne/data/datamodules.py
+++ b/yoyodyne/data/datamodules.py
@@ -72,7 +72,7 @@ class DataModule(lightning.LightningDataModule):
             max_target_length=max_target_length,
         )
 
-    def _make_index(self) -> indexes.Index:
+    def _make_index(self, model_dir: str) -> indexes.Index:
         # Computes index.
         source_vocabulary: Set[str] = set()
         features_vocabulary: Set[str] = set()
@@ -96,7 +96,7 @@ class DataModule(lightning.LightningDataModule):
         else:
             for source in self.parser.samples(self.train):
                 source_vocabulary.update(source)
-        return indexes.Index(
+        index = indexes.Index(
             source_vocabulary=sorted(source_vocabulary),
             features_vocabulary=(
                 sorted(features_vocabulary) if features_vocabulary else None
@@ -106,6 +106,8 @@ class DataModule(lightning.LightningDataModule):
             ),
             tie_embeddings=self.tie_embeddings,
         )
+        index.write(model_dir)
+        return index
 
     @staticmethod
     def pprint(vocabulary: Iterable) -> str:
@@ -127,10 +129,6 @@ class DataModule(lightning.LightningDataModule):
                 f"Target vocabulary: "
                 f"{self.pprint(self.index.target_vocabulary)}"
             )
-
-    def write_index(self, model_dir: str) -> None:
-        """Writes the index."""
-        self.index.write(model_dir)
 
     @property
     def has_features(self) -> bool:

--- a/yoyodyne/data/datamodules.py
+++ b/yoyodyne/data/datamodules.py
@@ -69,8 +69,12 @@ class DataModule(lightning.LightningDataModule):
         # TODO: it may not be necessary to store this.
         self.tie_embeddings = tie_embeddings
         self.batch_size = batch_size
+        # If the training data is specified, it is used to create (or recreate)
+        # the index; if not specified it is read from the model directory.
         self.index = (
-            index if index is not None else self._make_index(model_dir)
+            self._make_index(model_dir)
+            if self.train
+            else indexes.Index.read(model_dir)
         )
         self.collator = collators.Collator(
             has_features=self.has_features,

--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -149,6 +149,10 @@ class Index:
             return len(self.SPECIAL) + len(self.source_vocabulary)
 
     @property
+    def features_vocab_size(self) -> int:
+        return len(self.features_vocabulary) if self.features_vocabulary else 0
+
+    @property
     def target_vocab_size(self) -> int:
         if self.tie_embeddings:
             return self.vocab_size
@@ -156,7 +160,3 @@ class Index:
             return len(special.SPECIAL) + len(self.target_vocabulary)
         else:
             return 0
-
-    @property
-    def features_vocab_size(self) -> int:
-        return len(self.features_vocabulary) if self.features_vocabulary else 0

--- a/yoyodyne/models/expert.py
+++ b/yoyodyne/models/expert.py
@@ -24,7 +24,7 @@ from typing import (
 import numpy
 from maxwell import actions, sed
 
-from .. import data, defaults
+from .. import data, defaults, special
 
 
 class ActionError(Exception):
@@ -57,7 +57,7 @@ class ActionVocabulary:
         # Uses index from dataset to create action vocabulary.
         self.encode_actions([index(t) for t in index.target_vocabulary])
         # Sets unknown character decoding.
-        self.encode_actions([index.unk_idx])
+        self.encode_actions([special.UNK_IDX])
         # Adds source characters if index has tied embeddings.
         if index.tie_embeddings:
             self.encode_actions([index(s) for s in index.source_vocabulary])

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -3,7 +3,6 @@
 import argparse
 import csv
 import itertools
-import os
 
 import lightning
 
@@ -80,17 +79,6 @@ def get_model_from_argparse_args(
     return model_cls.load_from_checkpoint(args.checkpoint, **kwargs)
 
 
-def _mkdir(output: str) -> None:
-    """Creates directory for output file if necessary.
-
-    Args:
-        output (str): output to output file.
-    """
-    dirname = os.path.dirname(output)
-    if dirname:
-        os.makedirs(dirname, exist_ok=True)
-
-
 def predict(
     trainer: lightning.Trainer,
     model: models.BaseModel,
@@ -106,7 +94,7 @@ def predict(
          output (str).
     """
     util.log_info(f"Writing to {output}")
-    _mkdir(output)
+    util.mkpath(output)
     loader = datamodule.predict_dataloader()
     with open(output, "w", encoding=defaults.ENCODING) as sink:
         if model.beam_width > 1:

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -43,20 +43,20 @@ def get_datamodule_from_argparse_args(
         "transducer_grm",
         "transducer_lstm",
     ]
-    index = data.Index.read(args.model_dir)
+    # Please pass all arguments by keyword and keep in lexicographic order.
     return data.DataModule(
-        predict=args.predict,
         batch_size=args.batch_size,
-        source_col=args.source_col,
         features_col=args.features_col,
-        target_col=args.target_col,
-        source_sep=args.source_sep,
         features_sep=args.features_sep,
-        target_sep=args.target_sep,
-        separate_features=separate_features,
         max_source_length=args.max_source_length,
         max_target_length=args.max_target_length,
-        index=index,
+        model_dir=args.model_dir,
+        predict=args.predict,
+        separate_features=separate_features,
+        source_col=args.source_col,
+        source_sep=args.source_sep,
+        target_col=args.target_col,
+        target_sep=args.target_sep,
     )
 
 

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -148,20 +148,21 @@ def get_datamodule_from_argparse_args(
         "transducer_grm",
         "transducer_lstm",
     ]
+    # Please pass all arguments by keyword and keep in lexicographic order.
     datamodule = data.DataModule(
-        train=args.train,
-        val=args.val,
         batch_size=args.batch_size,
-        source_col=args.source_col,
         features_col=args.features_col,
-        target_col=args.target_col,
-        source_sep=args.source_sep,
         features_sep=args.features_sep,
-        target_sep=args.target_sep,
-        separate_features=separate_features,
         max_source_length=args.max_source_length,
         max_target_length=args.max_target_length,
+        model_dir=args.model_dir,
+        separate_features=separate_features,
+        source_sep=args.source_sep,
+        target_col=args.target_col,
+        target_sep=args.target_sep,
         tie_embeddings=args.tie_embeddings,
+        train=args.train,
+        val=args.val,
     )
     if not datamodule.has_target:
         raise Error("No target column specified")

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -165,7 +165,6 @@ def get_datamodule_from_argparse_args(
     )
     if not datamodule.has_target:
         raise Error("No target column specified")
-    datamodule.index.write(args.model_dir)
     datamodule.log_vocabularies()
     return datamodule
 

--- a/yoyodyne/util.py
+++ b/yoyodyne/util.py
@@ -1,14 +1,14 @@
 """Utilities."""
 
 import argparse
+import os
 import sys
+
 from typing import Any, Optional
 
 import torch
 
 from . import special
-
-# Argument parsing.
 
 
 class UniqueAddAction(argparse.Action):
@@ -24,7 +24,39 @@ class UniqueAddAction(argparse.Action):
         getattr(namespace, self.dest).add(values)
 
 
-# Tensor manipulation
+def log_info(msg: str) -> None:
+    """Logs msg to sys.stderr.
+
+    We can additionally consider logging to a file, or getting a handle to the
+    PL logger.
+
+    Args:
+        msg (str): the message to log.
+    """
+    print(msg, file=sys.stderr)
+
+
+def log_arguments(args: argparse.Namespace) -> None:
+    """Logs non-null arguments via log_info.
+
+    Args:
+        args (argparse.Namespace).
+    """
+    log_info("Arguments:")
+    for arg, val in vars(args).items():
+        if val is None:
+            continue
+        log_info(f"\t{arg}: {val!r}")
+
+
+def mkpath(path: str) -> None:
+    """Creates subdirectories for a path if they do not already exist.
+
+    Args:
+        path (str).
+    """
+    dirname = os.path.dirname(os.path.abspath(path))
+    os.makedirs(dirname, exist_ok=True)
 
 
 def pad_tensor_after_eos(
@@ -71,31 +103,3 @@ def pad_tensor_after_eos(
         with torch.inference_mode():
             predictions[i] = torch.cat((symbols, pads))
     return predictions
-
-
-# Logging.
-
-
-def log_info(msg: str) -> None:
-    """Logs msg to sys.stderr.
-
-    We can additionally consider logging to a file, or getting a handle to the
-    PL logger.
-
-    Args:
-        msg (str): the message to log.
-    """
-    print(msg, file=sys.stderr)
-
-
-def log_arguments(args: argparse.Namespace) -> None:
-    """Logs non-null arguments via log_info.
-
-    Args:
-        args (argparse.Namespace).
-    """
-    log_info("Arguments:")
-    for arg, val in vars(args).items():
-        if val is None:
-            continue
-        log_info(f"\t{arg}: {val!r}")


### PR DESCRIPTION
* Because the index is now all compromised of what `pickle` considers to be POD types (previously it consisted of separate `Vocabulary` objects), we can just load it directly without `setattr` now.
* To support this (and a few other things) we add a utility called `mkpath` which creates all the subdirectories needed and use this in all the cases where we are writing to a user-specified file.
* For simplicity we let the datamodule write the index. Less logic in `train` or `predict`: easier migration to LightningCLI.
* Gets rid of some unused stuff in the index.