### PR TITLE
One necessary `long` conversion

### DIFF
--- a/yoyodyne/models/modules/transformer.py
+++ b/yoyodyne/models/modules/transformer.py
@@ -259,8 +259,11 @@ class FeatureInvariantTransformerEncoder(TransformerEncoder):
             embedded (torch.Tensor): embedded tensor of shape
                 B x seq_len x embed_dim.
         """
-        # Distinguishes features and chars; 1 or 0.
-        char_mask = symbols < (self.num_embeddings - self.features_vocab_size)
+        # Distinguishes features and chars; 1 or 0; embedding layer requires
+        # this to be integral.
+        char_mask = (
+            symbols < (self.num_embeddings - self.features_vocab_size)
+        ).long()
         type_embedding = self.esq * self.type_embedding(char_mask)
         word_embedding = self.esq * self.embeddings(symbols)
         positional_embedding = self.positional_encoding(


### PR DESCRIPTION
This reverses a line in #264.

I think this only affects CPU or MPS; error without reads:

```
  File ".../site-packages/torch/nn/functional.py", line 2551, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Expected tensor for argument #1 'indices' to have one of the following scalar types: Long, Int; but got CPUBoolType instead (while checking arguments for embedding)
```