### PR TITLE
Replaces notional argmaxes with `torch.argmax`

### DIFF
--- a/yoyodyne/evaluators.py
+++ b/yoyodyne/evaluators.py
@@ -71,7 +71,7 @@ class Evaluator(abc.ABC):
             )
         if not predictions_finalized:
             # Gets the max value at each dim2 in predictions.
-            _, predictions = torch.max(predictions, dim=2)
+            predictions = torch.argmax(predictions, dim=2)
             # Finalizes the predictions.
             predictions = self.finalize_predictions(predictions)
         golds = self.finalize_golds(golds)

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -314,8 +314,7 @@ class BaseModel(lightning.LightningModule):
             torch.Tensor: indices of the argmax at each timestep.
         """
         assert len(predictions.size()) == 3
-        _, indices = torch.max(predictions, dim=2)
-        return indices
+        return torch.argmax(predictions, dim=2)
 
     def configure_optimizers(
         self,

--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -217,7 +217,7 @@ class HardAttentionRNNModel(rnn.RNNModel):
         """
         tgt_prob = likelihood + log_probs.transpose(1, 2)
         tgt_prob = tgt_prob.logsumexp(dim=-1)
-        tgt_char = torch.max(tgt_prob, dim=-1)[1]
+        tgt_char = torch.argmax(tgt_prob, dim=-1)
         return tgt_char.unsqueeze(-1), likelihood
 
     @staticmethod

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -917,7 +917,7 @@ class PointerGeneratorTransformerModel(
             last_output = scores[:, -1, :]
             outputs.append(last_output)
             # -> B x 1 x 1.
-            _, pred = torch.max(last_output, dim=1)
+            pred = torch.argmax(last_output, dim=1)
             predictions.append(pred)
             # Updates to track which sequences have decoded an END.
             finished = torch.logical_or(

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -118,7 +118,7 @@ class TransformerModel(base.BaseModel):
             last_output = logits[:, -1, :]  # Ignores END.
             outputs.append(last_output)
             # -> B x 1 x 1
-            _, pred = torch.max(last_output, dim=1)
+            pred = torch.argmax(last_output, dim=1)
             predictions.append(pred)
             # Updates to track which sequences have decoded an END.
             finished = torch.logical_or(


### PR DESCRIPTION
Reviewing the code I noticed quite a few places where we use `torch.max`, which returns a max/argmax tuple, but then we throw away the max using either `_, argmax = torch.max(...)` or `argmax = torch.max(...)[1]`. In each case, found using `grep`, I just use `torch.argmax` instead. Whether or not this is more performant it expresses the intention more clearly.