### PR TITLE
Simplifies greedy decoding in the RNN

### DIFF
--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -222,8 +222,6 @@ class RNNModel(base.BaseModel):
                 # Under teacher forcing the next input is the gold symbol for
                 # this step.
                 decoder_input = target[:, t].unsqueeze(1)
-            # Otherwise we pass the top pred to the next timestep
-            # (i.e., student forcing, greedy decoding).
             else:
                 # Otherwise, under student forcing, the next input is the top
                 # prediction.

--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -48,7 +48,7 @@ class RNNModel(base.BaseModel):
         encoder_out: torch.Tensor,
         encoder_mask: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Decodes with a beam.
+        """Decodes with beam search.
 
         Args:
             encoder_out (torch.Tensor): batch of encoded input symbols.


### PR DESCRIPTION
The length bounds for greedy decoding are as follows:

* If a target is provided, we need loss and maybe also are doing teacher forcing, and therefore do as many decoding steps as the longest sequence in the target tensor.
* If no target is provided, then `max_target_length` acts as an upper bound. However, we can halt earlier if all sequences have decoded at least one END.

This disjunction is currently not well encoded: we generate a vector
`finished` (tracking the presence of END in the sequences), and repeatedly update and test it, even in the case where a target is present. This PR fixes that: the vector is only generated, updated, and tested if no target is present.

We also update the method docs to reflect this and to draw the contrast with beam decoding.

This has no effects on the predictions generated, it just saves some training time.