### PR TITLE
Enforce abstraction with PEP 3119

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,10 +408,8 @@ accelerator. Furthermore, since it is developed at "low-intensity" by a
 geographically-dispersed team, consistency is particularly important. Some
 consistency decisions made thus far:
 
--   The abstract/concrete class distinction is enforced at runtime by the
-    presence of methods raising `NotImplementedError`, though in the future we
-    may consider [PEP 3119](https://peps.python.org/pep-3119/)-style
-    "compile-time" enforcement.
+-   Abstract classes overrides are enforced using [PEP
+    3119](https://peps.python.org/pep-3119/).
 -   [`numpy`](https://numpy.org/) is used for basic mathematical operations and
     constants even in places where the built-in
     [`math`](https://docs.python.org/3/library/math.html) would do.
@@ -432,8 +430,8 @@ calling them as functions (which invokes their `forward` methods); however, in
 some cases it is also necessary for the model to call ancillary members or
 methods of its modules. The `base.ModuleOutput` class is used to capture the
 output of the various modules, and it is this which is essential to, e.g.,
-abstracting between different kinds of encoders which may or may not have
-hidden or cell state to return.
+abstracting between different kinds of encoders which may or may not have hidden
+or cell state to return.
 
 #### Decoding strategies
 

--- a/yoyodyne/data/datamodules.py
+++ b/yoyodyne/data/datamodules.py
@@ -138,7 +138,9 @@ class DataModule(lightning.LightningDataModule):
             features_vocabulary=(
                 features_vocabulary if features_vocabulary else None
             ),
-            target_vocabulary=target_vocabulary if target_vocabulary else None,
+            target_vocabulary=(
+                target_vocabulary if target_vocabulary else None
+            ),
             tie_embeddings=tie_embeddings,
         )
         # Writes it to the model directory.

--- a/yoyodyne/evaluators.py
+++ b/yoyodyne/evaluators.py
@@ -77,27 +77,32 @@ class Evaluator(abc.ABC):
         golds = self.finalize_golds(golds)
         return self.get_eval_item(predictions, golds)
 
+    @abc.abstractmethod
     def get_eval_item(
         self,
         predictions: torch.Tensor,
         golds: torch.Tensor,
     ) -> EvalItem:
-        raise NotImplementedError
+        ...
 
+    @abc.abstractmethod
     def finalize_predictions(
         self,
         predictions: torch.Tensor,
     ) -> torch.Tensor:
-        raise NotImplementedError
+        ...
 
+    @abc.abstractmethod
     def finalize_golds(
         self,
         predictions: torch.Tensor,
     ) -> torch.Tensor:
-        raise NotImplementedError
+        ...
 
+    @property
+    @abc.abstractmethod
     def name(self) -> str:
-        raise NotImplementedError
+        ...
 
 
 class AccuracyEvaluator(Evaluator):

--- a/yoyodyne/evaluators.py
+++ b/yoyodyne/evaluators.py
@@ -82,27 +82,23 @@ class Evaluator(abc.ABC):
         self,
         predictions: torch.Tensor,
         golds: torch.Tensor,
-    ) -> EvalItem:
-        ...
+    ) -> EvalItem: ...
 
     @abc.abstractmethod
     def finalize_predictions(
         self,
         predictions: torch.Tensor,
-    ) -> torch.Tensor:
-        ...
+    ) -> torch.Tensor: ...
 
     @abc.abstractmethod
     def finalize_golds(
         self,
         predictions: torch.Tensor,
-    ) -> torch.Tensor:
-        ...
+    ) -> torch.Tensor: ...
 
     @property
     @abc.abstractmethod
-    def name(self) -> str:
-        ...
+    def name(self) -> str: ...
 
 
 class AccuracyEvaluator(Evaluator):

--- a/yoyodyne/models/__init__.py
+++ b/yoyodyne/models/__init__.py
@@ -3,11 +3,19 @@
 import argparse
 
 from .. import defaults
-from .base import BaseModel
 
+# These are used to call the `add_argparse_args` functions.
+from . import base as _base
+from . import expert as _expert
+from . import hard_attention as _hard_attention
+from . import modules as _modules
+from . import rnn as _rnn
+from . import transformer as _transformer
+
+# These are used to export the models themselves.
+from .base import BaseModel
 from .hard_attention import HardAttentionGRUModel
 from .hard_attention import HardAttentionLSTMModel
-from .hard_attention import HardAttentionRNNModel  # noqa: F401
 from .pointer_generator import PointerGeneratorGRUModel
 from .pointer_generator import PointerGeneratorLSTMModel
 from .pointer_generator import PointerGeneratorTransformerModel
@@ -15,22 +23,21 @@ from .rnn import AttentiveGRUModel
 from .rnn import AttentiveLSTMModel
 from .rnn import GRUModel
 from .rnn import LSTMModel
-from .rnn import RNNModel  # noqa: F401
-
-from .transducer import TransducerGRUModel, TransducerLSTMModel  # noqa: F401
+from .transducer import TransducerGRUModel
+from .transducer import TransducerLSTMModel
 from .transformer import TransformerModel
 
 
 _model_fac = {
     "attentive_gru": AttentiveGRUModel,
     "attentive_lstm": AttentiveLSTMModel,
+    "gru": GRUModel,
     "hard_attention_gru": HardAttentionGRUModel,
     "hard_attention_lstm": HardAttentionLSTMModel,
+    "lstm": LSTMModel,
     "pointer_generator_gru": PointerGeneratorGRUModel,
     "pointer_generator_lstm": PointerGeneratorLSTMModel,
-    "pointer_generator_transformer": PointerGeneratorTransformerModel,  # noqa: E501
-    "gru": GRUModel,
-    "lstm": LSTMModel,
+    "pointer_generator_transformer": PointerGeneratorTransformerModel,
     "transducer_gru": TransducerGRUModel,
     "transducer_lstm": TransducerLSTMModel,
     "transformer": TransformerModel,
@@ -79,6 +86,12 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
     Args:
         parser (argparse.ArgumentParser).
     """
+    _base.add_argparse_args(parser)
+    _expert.add_argparse_args(parser)
+    _hard_attention.add_argparse_args(parser)
+    _modules.add_argparse_args(parser)
+    _rnn.add_argparse_args(parser)
+    _transformer.add_argparse_args(parser)
     parser.add_argument(
         "--arch",
         choices=_model_fac.keys(),

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -1,7 +1,17 @@
 """Base model class, with PL integration."""
 
+import abc
 import argparse
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import lightning
 import torch
@@ -19,8 +29,8 @@ from .. import (
 from . import modules
 
 
-class BaseModel(lightning.LightningModule):
-    """Base class, handling Lightning integration."""
+class BaseModel(abc.ABC, lightning.LightningModule):
+    """Abstract base class for models handling Lightning integration."""
 
     #  TODO: clean up type checking here.
     # Sizes.
@@ -157,168 +167,25 @@ class BaseModel(lightning.LightningModule):
             util.log_info(f"Encoder: {self.source_encoder.name}")
         util.log_info(f"Decoder: {self.decoder.name}")
 
-    @staticmethod
-    def init_embeddings(num_embed: int, embed_size: int) -> nn.Embedding:
-        """Method interface for initializing the embedding layer.
-
-        Args:
-            num_embeddings (int): number of embeddings.
-            embedding_size (int): dimension of embeddings.
-
-        Raises:
-            NotImplementedError: This method needs to be overridden.
-
-        Returns:
-            nn.Embedding: embedding layer.
-        """
-        raise NotImplementedError
-
-    def get_decoder(self):
-        raise NotImplementedError
-
-    @property
-    def num_parameters(self) -> int:
-        return sum(part.numel() for part in self.parameters())
-
-    @property
-    def has_features_encoder(self):
-        return self.features_encoder is not None
-
-    def training_step(
+    def _get_loss_func(
         self,
-        batch: data.PaddedBatch,
-        batch_idx: int,
-    ) -> torch.Tensor:
-        """Runs one step of training.
-
-        This is called by the PL Trainer.
-
-        Args:
-            batch (data.PaddedBatch)
-            batch_idx (int).
+    ) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
+        """Returns the actual function used to compute loss.
 
         Returns:
-            torch.Tensor: loss.
+            Callable[[torch.Tensor, torch.Tensor], torch.Tensor]: configured
+                loss function.
         """
-        # -> B x seq_len x target_vocab_size.
-        predictions = self(batch)
-        target_padded = batch.target.padded
-        # -> B x target_vocab_size x seq_len. For loss.
-        predictions = predictions.transpose(1, 2)
-        loss = self.loss_func(predictions, target_padded)
-        self.log(
-            "train_loss",
-            loss,
-            batch_size=len(batch),
-            on_step=False,
-            on_epoch=True,
+        return nn.CrossEntropyLoss(
+            ignore_index=special.PAD_IDX,
+            label_smoothing=self.label_smoothing,
         )
-        return loss
-
-    def validation_step(
-        self,
-        batch: data.PaddedBatch,
-        batch_idx: int,
-    ) -> Dict:
-        """Runs one validation step.
-
-        This is called by the PL Trainer.
-
-        Args:
-            batch (data.PaddedBatch).
-            batch_idx (int).
-
-        Returns:
-            Dict[str, float]: validation metrics.
-        """
-        # Greedy decoding.
-        # -> B x seq_len x target_vocab_size.
-        target_padded = batch.target.padded
-        greedy_predictions = self(batch)
-        # Gets a dict of all eval metrics for this batch.
-        val_eval_items_dict = {
-            evaluator.name: evaluator.evaluate(
-                greedy_predictions, target_padded
-            )
-            for evaluator in self.evaluators
-        }
-        # -> B x target_vocab_size x seq_len. For loss.
-        greedy_predictions = greedy_predictions.transpose(1, 2)
-        # Truncates predictions to the size of the target.
-        greedy_predictions = torch.narrow(
-            greedy_predictions, 2, 0, target_padded.size(1)
-        )
-        loss = self.loss_func(greedy_predictions, target_padded)
-        val_eval_items_dict.update({"val_loss": loss})
-        return val_eval_items_dict
-
-    def validation_epoch_end(self, validation_step_outputs: Dict) -> Dict:
-        """Computes average loss and average accuracy.
-
-        Args:
-            validation_step_outputs (Dict).
-
-        Returns:
-            Dict: averaged metrics over all validation steps.
-        """
-        avg_val_loss = torch.tensor(
-            [v["val_loss"] for v in validation_step_outputs]
-        ).mean()
-        # Gets requested metrics.
-        metrics = {
-            metric_name: sum(
-                (v[metric_name] for v in validation_step_outputs),
-                start=evaluators.EvalItem([]),
-            ).metric
-            for metric_name in self.eval_metrics
-        }
-        # Always logs validation loss.
-        metrics.update({"loss": avg_val_loss})
-        # del validation_step_outputs
-        for metric, value in metrics.items():
-            self.log(f"val_{metric}", value, prog_bar=True)
-        return metrics
-
-    def predict_step(
-        self,
-        batch: data.PaddedBatch,
-        batch_idx: int,
-    ) -> Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
-        """Runs one predict step.
-
-        This is called by the PL Trainer.
-
-        Args:
-            batch (data.PaddedBatch).
-            batch_idx (int).
-
-        Returns:
-            Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]: if
-                using beam search, the predictions and scores as a tuple of
-                tensors; if using greedy search, the predictions as a tensor.
-        """
-
-        if self.beam_width > 1:
-            return self(batch)
-        else:
-            return self._get_predicted(self(batch))
-
-    def _get_predicted(self, predictions: torch.Tensor) -> torch.Tensor:
-        """Picks the best index from the vocabulary.
-
-        Args:
-            predictions (torch.Tensor): B x seq_len x target_vocab_size.
-
-        Returns:
-            torch.Tensor: indices of the argmax at each timestep.
-        """
-        assert len(predictions.size()) == 3
-        return torch.argmax(predictions, dim=2)
 
     def configure_optimizers(
         self,
     ) -> Union[
-        optim.Optimizer, Tuple[List[optim.Optimizer], List[Dict[str, Any]]]
+        optim.Optimizer,
+        Tuple[List[optim.Optimizer], List[Dict[str, Any]]],
     ]:
         """Gets the configured torch optimizer and scheduler.
 
@@ -367,112 +234,247 @@ class BaseModel(lightning.LightningModule):
             self.scheduler, optimizer, **dict(self.scheduler_kwargs)
         )
 
-    def _get_loss_func(
+    @abc.abstractmethod
+    def get_decoder(self): ...
+
+    @staticmethod
+    @abc.abstractmethod
+    def init_embeddings(
+        num_embeddings: int, embedding_size: int
+    ) -> nn.Embedding: ...
+
+    @property
+    def has_features_encoder(self):
+        return self.features_encoder is not None
+
+    @property
+    def num_parameters(self) -> int:
+        return sum(part.numel() for part in self.parameters())
+
+    def training_step(
         self,
-    ) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
-        """Returns the actual function used to compute loss.
+        batch: data.PaddedBatch,
+        batch_idx: int,
+    ) -> torch.Tensor:
+        """Runs one step of training.
+
+        This is called by the PL Trainer.
+
+        Args:
+            batch (data.PaddedBatch)
+            batch_idx (int).
 
         Returns:
-            Callable[[torch.Tensor, torch.Tensor], torch.Tensor]: configured
-                loss function.
+            torch.Tensor: loss.
         """
-        return nn.CrossEntropyLoss(
-            ignore_index=special.PAD_IDX,
-            label_smoothing=self.label_smoothing,
+        # -> B x seq_len x target_vocab_size.
+        predictions = self(batch)
+        target_padded = batch.target.padded
+        # -> B x target_vocab_size x seq_len. For loss.
+        predictions = predictions.transpose(1, 2)
+        loss = self.loss_func(predictions, target_padded)
+        self.log(
+            "train_loss",
+            loss,
+            batch_size=len(batch),
+            on_step=False,
+            on_epoch=True,
         )
+        return loss
 
-    @staticmethod
-    def add_predict_argparse_args(parser: argparse.ArgumentParser) -> None:
-        """Adds shared configuration options to the argument parser.
-
-        These are only needed at prediction time.
+    def validation_epoch_end(self, validation_step_outputs: Dict) -> Dict:
+        """Computes average loss and average accuracy.
 
         Args:
-            parser (argparse.ArgumentParser).
+            validation_step_outputs (Dict).
+
+        Returns:
+            Dict: averaged metrics over all validation steps.
         """
-        # Beam search arguments.
-        parser.add_argument(
-            "--beam_width",
-            type=int,
-            required=False,
-            help="Size of the beam for beam search. Default: %(default)s.",
-        )
+        avg_val_loss = torch.tensor(
+            [v["val_loss"] for v in validation_step_outputs]
+        ).mean()
+        # Gets requested metrics.
+        metrics = {
+            metric_name: sum(
+                (v[metric_name] for v in validation_step_outputs),
+                start=evaluators.EvalItem([]),
+            ).metric
+            for metric_name in self.eval_metrics
+        }
+        # Always logs validation loss.
+        metrics.update({"loss": avg_val_loss})
+        # del validation_step_outputs
+        for metric, value in metrics.items():
+            self.log(f"val_{metric}", value, prog_bar=True)
+        return metrics
 
-    @staticmethod
-    def add_argparse_args(parser: argparse.ArgumentParser) -> None:
-        """Adds shared configuration options to the argument parser.
+    def validation_step(
+        self,
+        batch: data.PaddedBatch,
+        batch_idx: int,
+    ) -> Dict:
+        """Runs one validation step.
 
-        These are only needed at training time.
+        This is called by the PL Trainer.
 
         Args:
-            parser (argparse.ArgumentParser).
+            batch (data.PaddedBatch).
+            batch_idx (int).
+
+        Returns:
+            Dict[str, float]: validation metrics.
         """
-        # Optimizer arguments.
-        parser.add_argument(
-            "--beta1",
-            type=float,
-            default=defaults.BETA1,
-            help="beta_1 (Adam optimizer only). Default: %(default)s.",
+        # Greedy decoding.
+        # -> B x seq_len x target_vocab_size.
+        target_padded = batch.target.padded
+        greedy_predictions = self(batch)
+        # Gets a dict of all eval metrics for this batch.
+        val_eval_items_dict = {
+            evaluator.name: evaluator.evaluate(
+                greedy_predictions, target_padded
+            )
+            for evaluator in self.evaluators
+        }
+        # -> B x target_vocab_size x seq_len. For loss.
+        greedy_predictions = greedy_predictions.transpose(1, 2)
+        # Truncates predictions to the size of the target.
+        greedy_predictions = torch.narrow(
+            greedy_predictions, 2, 0, target_padded.size(1)
         )
-        parser.add_argument(
-            "--beta2",
-            type=float,
-            default=defaults.BETA2,
-            help="beta_2 (Adam optimizer only). Default: %(default)s.",
-        )
-        parser.add_argument(
-            "--learning_rate",
-            type=float,
-            default=defaults.LEARNING_RATE,
-            help="Learning rate. Default: %(default)s.",
-        )
-        parser.add_argument(
-            "--optimizer",
-            choices=optimizers.OPTIMIZERS,
-            default=defaults.OPTIMIZER,
-            help="Optimizer. Default: %(default)s.",
-        )
-        parser.add_argument(
-            "--scheduler",
-            choices=schedulers.SCHEDULERS,
-            help="Learning rate scheduler.",
-        )
-        # Regularization arguments.
-        parser.add_argument(
-            "--dropout",
-            type=float,
-            default=defaults.DROPOUT,
-            help="Dropout probability. Default: %(default)s.",
-        )
-        parser.add_argument(
-            "--label_smoothing",
-            type=float,
-            default=defaults.LABEL_SMOOTHING,
-            help="Coefficient for label smoothing. Default: %(default)s.",
-        )
-        # Model arguments.
-        parser.add_argument(
-            "--decoder_layers",
-            type=int,
-            default=defaults.DECODER_LAYERS,
-            help="Number of decoder layers. Default: %(default)s.",
-        )
-        parser.add_argument(
-            "--encoder_layers",
-            type=int,
-            default=defaults.ENCODER_LAYERS,
-            help="Number of encoder layers. Default: %(default)s.",
-        )
-        parser.add_argument(
-            "--embedding_size",
-            type=int,
-            default=defaults.EMBEDDING_SIZE,
-            help="Dimensionality of embeddings. Default: %(default)s.",
-        )
-        parser.add_argument(
-            "--hidden_size",
-            type=int,
-            default=defaults.HIDDEN_SIZE,
-            help="Dimensionality of the hidden layer(s). "
-            "Default: %(default)s.",
-        )
+        loss = self.loss_func(greedy_predictions, target_padded)
+        val_eval_items_dict.update({"val_loss": loss})
+        return val_eval_items_dict
+
+    def predict_step(
+        self,
+        batch: data.PaddedBatch,
+        batch_idx: int,
+    ) -> Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
+        """Runs one predict step.
+
+        This is called by the PL Trainer.
+
+        Args:
+            batch (data.PaddedBatch).
+            batch_idx (int).
+
+        Returns:
+            Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]: if
+                using beam search, the predictions and scores as a tuple of
+                tensors; if using greedy search, the predictions as a tensor.
+        """
+
+        if self.beam_width > 1:
+            return self(batch)
+        else:
+            return self._get_predicted(self(batch))
+
+    def _get_predicted(self, predictions: torch.Tensor) -> torch.Tensor:
+        """Picks the best index from the vocabulary.
+
+        Args:
+            predictions (torch.Tensor): B x seq_len x target_vocab_size.
+
+        Returns:
+            torch.Tensor: indices of the argmax at each timestep.
+        """
+        assert len(predictions.size()) == 3
+        return torch.argmax(predictions, dim=2)
+
+
+def add_predict_argparse_args(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """Adds shared configuration options to the argument parser.
+
+    These are only needed at prediction time.
+
+    Args:
+        parser (argparse.ArgumentParser).
+    """
+    # Beam search arguments.
+    parser.add_argument(
+        "--beam_width",
+        type=int,
+        required=False,
+        help="Size of the beam for beam search. Default: %(default)s.",
+    )
+
+
+def add_argparse_args(parser: argparse.ArgumentParser) -> None:
+    """Adds shared configuration options to the argument parser.
+
+    These are only needed at training time.
+
+    Args:
+        parser (argparse.ArgumentParser).
+    """
+    # Optimizer arguments.
+    parser.add_argument(
+        "--beta1",
+        type=float,
+        default=defaults.BETA1,
+        help="beta_1 (Adam optimizer only). Default: %(default)s.",
+    )
+    parser.add_argument(
+        "--beta2",
+        type=float,
+        default=defaults.BETA2,
+        help="beta_2 (Adam optimizer only). Default: %(default)s.",
+    )
+    parser.add_argument(
+        "--learning_rate",
+        type=float,
+        default=defaults.LEARNING_RATE,
+        help="Learning rate. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "--optimizer",
+        choices=optimizers.OPTIMIZERS,
+        default=defaults.OPTIMIZER,
+        help="Optimizer. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "--scheduler",
+        choices=schedulers.SCHEDULERS,
+        help="Learning rate scheduler.",
+    )
+    # Regularization arguments.
+    parser.add_argument(
+        "--dropout",
+        type=float,
+        default=defaults.DROPOUT,
+        help="Dropout probability. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "--label_smoothing",
+        type=float,
+        default=defaults.LABEL_SMOOTHING,
+        help="Coefficient for label smoothing. Default: %(default)s.",
+    )
+    # Model arguments.
+    parser.add_argument(
+        "--decoder_layers",
+        type=int,
+        default=defaults.DECODER_LAYERS,
+        help="Number of decoder layers. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "--encoder_layers",
+        type=int,
+        default=defaults.ENCODER_LAYERS,
+        help="Number of encoder layers. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "--embedding_size",
+        type=int,
+        default=defaults.EMBEDDING_SIZE,
+        help="Dimensionality of embeddings. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "--hidden_size",
+        type=int,
+        default=defaults.HIDDEN_SIZE,
+        help="Dimensionality of the hidden layer(s). " "Default: %(default)s.",
+    )

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -382,25 +382,6 @@ class BaseModel(abc.ABC, lightning.LightningModule):
         return torch.argmax(predictions, dim=2)
 
 
-def add_predict_argparse_args(
-    parser: argparse.ArgumentParser,
-) -> None:
-    """Adds shared configuration options to the argument parser.
-
-    These are only needed at prediction time.
-
-    Args:
-        parser (argparse.ArgumentParser).
-    """
-    # Beam search arguments.
-    parser.add_argument(
-        "--beam_width",
-        type=int,
-        required=False,
-        help="Size of the beam for beam search. Default: %(default)s.",
-    )
-
-
 def add_argparse_args(parser: argparse.ArgumentParser) -> None:
     """Adds shared configuration options to the argument parser.
 

--- a/yoyodyne/models/expert.py
+++ b/yoyodyne/models/expert.py
@@ -3,11 +3,9 @@
 Given an input string x, a target string t, alignment index i, and a partial
 prediction y, it returns optimal cost-to-go for all valid edit actions.
 
-Also includes ActionVocabulary class for compatibility with maxwell dictionary.
-Class stores valid edit actions for given dataset.
-"""
+Also includes ActionVocabulary class for compatibility with the `maxwell`
+dictionary. This class stores valid edit actions for given dataset."""
 
-import abc
 import argparse
 import dataclasses
 from typing import (
@@ -203,11 +201,11 @@ class ActionPrefix:
 def edit_distance(
     x: Sequence[Any],
     y: Sequence[Any],
-    del_cost=1.0,
-    ins_cost=1.0,
-    sub_cost=1.0,
-    x_offset=0,
-    y_offset=0,
+    del_cost: float = 1.0,
+    ins_cost: float = 1.0,
+    sub_cost: float = 1.0,
+    x_offset: int = 0,
+    y_offset: int = 0,
 ) -> numpy.ndarray:
     """Generates edit distance matrix from source (x) to target (y).
 
@@ -246,7 +244,7 @@ def edit_distance(
     return prefix_matrix
 
 
-class Expert(abc.ABC):
+class Expert:
     """Oracle scores possible edit actions between prediction and target.
 
     Args:
@@ -386,7 +384,7 @@ class Expert(abc.ABC):
         target: Sequence[Any],
         alignment: int,
         prediction: Sequence[Any],
-        max_action_seq_len=150,
+        max_action_seq_len: int = 150,
     ) -> Dict[actions.Edit, float]:
         """Provides potential actions given source, target, and prediction.
 

--- a/yoyodyne/models/modules/__init__.py
+++ b/yoyodyne/models/modules/__init__.py
@@ -5,6 +5,7 @@ import argparse
 from .base import BaseModule
 from .hard_attention import ContextHardAttentionGRUDecoder  # noqa: F401
 from .hard_attention import ContextHardAttentionLSTMDecoder  # noqa: F401
+from .hard_attention import HardAttentionRNNDecoder  # noqa: F401
 from .hard_attention import HardAttentionGRUDecoder  # noqa: F401
 from .hard_attention import HardAttentionLSTMDecoder  # noqa: F401
 from .linear import LinearEncoder

--- a/yoyodyne/models/modules/__init__.py
+++ b/yoyodyne/models/modules/__init__.py
@@ -15,6 +15,7 @@ from .rnn import GRUDecoder  # noqa: F401
 from .rnn import GRUEncoder
 from .rnn import LSTMDecoder  # noqa: F401
 from .rnn import LSTMEncoder
+from .rnn import RNNDecoder  # noqa: F401
 from .transformer import TransformerDecoder  # noqa: F401
 from .transformer import FeatureInvariantTransformerEncoder
 from .transformer import TransformerEncoder

--- a/yoyodyne/models/modules/attention.py
+++ b/yoyodyne/models/modules/attention.py
@@ -60,7 +60,7 @@ class Attention(nn.Module):
         # B  x seq_len x decoder_dim.
         hidden = hidden.repeat(1, encoder_outputs.size(1), 1)
         # Gets the scores of each time step in the output.
-        attention_scores = self.score(hidden, encoder_outputs)
+        attention_scores = self._score(hidden, encoder_outputs)
         # Masks the scores with -inf at each padded character so that softmax
         # computes a 0 towards the distribution for that cell.
         attention_scores.data.masked_fill_(mask, defaults.NEG_INF)
@@ -70,7 +70,7 @@ class Attention(nn.Module):
         weighted = torch.bmm(weights, encoder_outputs)
         return weighted, weights
 
-    def score(
+    def _score(
         self, hidden: torch.Tensor, encoder_outputs: torch.Tensor
     ) -> torch.Tensor:
         """Computes the scores with concat attention.

--- a/yoyodyne/models/modules/base.py
+++ b/yoyodyne/models/modules/base.py
@@ -31,6 +31,8 @@ class ModuleOutput:
 
 
 class BaseModule(abc.ABC, lightning.LightningModule):
+    """Abstract base class for encoder and decoder modules."""
+
     # Sizes.
     num_embeddings: int
     # Regularization arguments.

--- a/yoyodyne/models/modules/base.py
+++ b/yoyodyne/models/modules/base.py
@@ -1,5 +1,6 @@
 """Base module class with PL integration."""
 
+import abc
 import dataclasses
 from typing import Optional, Union, Tuple
 
@@ -29,7 +30,7 @@ class ModuleOutput:
         return self.embeddings is not None
 
 
-class BaseModule(lightning.LightningModule):
+class BaseModule(abc.ABC, lightning.LightningModule):
     # Sizes.
     num_embeddings: int
     # Regularization arguments.
@@ -76,5 +77,9 @@ class BaseModule(lightning.LightningModule):
         return self.dropout_layer(embedded)
 
     @property
-    def output_size(self) -> int:
-        raise NotImplementedError
+    @abc.abstractmethod
+    def name(self) -> str: ...
+
+    @property
+    @abc.abstractmethod
+    def output_size(self) -> int: ...

--- a/yoyodyne/models/modules/hard_attention.py
+++ b/yoyodyne/models/modules/hard_attention.py
@@ -8,7 +8,7 @@ from . import base, rnn
 
 
 class HardAttentionRNNDecoder(rnn.RNNDecoder):
-    """Base module for zeroth-order HMM hard attention RNN decoders."""
+    """Abstract base class for zeroth-order HMM hard attention RNN decoders."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -146,7 +146,7 @@ class HardAttentionLSTMDecoder(HardAttentionRNNDecoder):
 
 
 class ContextHardAttentionRNNDecoder(HardAttentionRNNDecoder):
-    """Base module for first-order HMM hard attention RNN decoder."""
+    """Abstract base class for first-order HMM hard attention RNN decoder."""
 
     def __init__(self, attention_context, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/yoyodyne/models/modules/linear.py
+++ b/yoyodyne/models/modules/linear.py
@@ -5,6 +5,7 @@ from . import base
 
 
 class LinearEncoder(base.BaseModule):
+
     def forward(self, source: data.PaddedTensor) -> base.ModuleOutput:
         """Encodes the input.
 

--- a/yoyodyne/models/modules/rnn.py
+++ b/yoyodyne/models/modules/rnn.py
@@ -1,5 +1,6 @@
 """RNN module classes."""
 
+import abc
 from typing import Tuple
 
 import torch
@@ -10,7 +11,7 @@ from . import attention, base
 
 
 class RNNModule(base.BaseModule):
-    """Base class for RNN modules.
+    """Abstract base class for RNN modules.
 
     Args:
         bidirectional (bool).
@@ -34,16 +35,12 @@ class RNNModule(base.BaseModule):
     def num_directions(self) -> int:
         return 2 if self.bidirectional else 1
 
-    def get_module(self):
-        raise NotImplementedError
-
-    @property
-    def name(self) -> str:
-        raise NotImplementedError
+    @abc.abstractmethod
+    def get_module(self) -> nn.RNNBase: ...
 
 
 class RNNEncoder(RNNModule):
-    """Base class for RNN encoders."""
+    """Abstract base class for RNN encoders."""
 
     def forward(self, source: data.PaddedTensor) -> base.ModuleOutput:
         """Encodes the input.
@@ -115,7 +112,7 @@ class LSTMEncoder(RNNEncoder):
 
 
 class RNNDecoder(RNNModule):
-    """Base class for RNN decoders."""
+    """Abstract base class for RNN decoders."""
 
     def __init__(self, decoder_input_size, *args, **kwargs):
         self.decoder_input_size = decoder_input_size
@@ -209,7 +206,7 @@ class LSTMDecoder(RNNDecoder):
 
 
 class AttentiveRNNDecoder(RNNDecoder):
-    """Base class for attentive RNN decoders."""
+    """Abstract base class for attentive RNN decoders."""
 
     def __init__(self, attention_input_size, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/yoyodyne/models/modules/rnn.py
+++ b/yoyodyne/models/modules/rnn.py
@@ -1,7 +1,7 @@
 """RNN module classes."""
 
 import abc
-from typing import Tuple
+from typing import Tuple, Union
 
 import torch
 from torch import nn
@@ -60,7 +60,7 @@ class RNNEncoder(RNNModule):
             batch_first=True,
             enforce_sorted=False,
         )
-        # -> B x seq_len x encoder_dim, hiddens
+        # -> B x seq_len x target_vocab_size, hiddens
         packed_outs, hiddens = self.module(packed)
         encoded, _ = nn.utils.rnn.pad_packed_sequence(
             packed_outs,
@@ -112,7 +112,11 @@ class LSTMEncoder(RNNEncoder):
 
 
 class RNNDecoder(RNNModule):
-    """Abstract base class for RNN decoders."""
+    """Abstract base class for RNN decoders.
+
+    This implementation is inattentive; it uses the last (non-padding) hidden
+    state of the encoder as the input to the decoder.
+    """
 
     def __init__(self, decoder_input_size, *args, **kwargs):
         self.decoder_input_size = decoder_input_size
@@ -121,7 +125,7 @@ class RNNDecoder(RNNModule):
     def forward(
         self,
         symbol: torch.Tensor,
-        last_hiddens: torch.Tensor,
+        last_hiddens: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
         encoder_out: torch.Tensor,
         encoder_mask: torch.Tensor,
     ) -> base.ModuleOutput:
@@ -129,11 +133,11 @@ class RNNDecoder(RNNModule):
 
         Args:
             symbol (torch.Tensor): previously decoded symbol of shape B x 1.
-            last_hiddens (Tuple[torch.Tensor, torch.Tensor]): last hidden
-                states from the decoder of shape
-                (1 x B x decoder_dim, 1 x B x decoder_dim).
+            last_hiddens (Union[torch.Tensor, Tuple[torch.Tensor,
+                torch.Tensor]]): last hidden states from the decoder of shape
+                1 x B x decoder_dim.
             encoder_out (torch.Tensor): encoded input sequence of shape
-                B x seq_len x encoder_dim.
+                B x seq_len x target_vocab_size.
             encoder_mask (torch.Tensor): mask for the encoded input batch of
                 shape B x seq_len.
 
@@ -142,27 +146,36 @@ class RNNDecoder(RNNModule):
                 from the decoder RNN.
         """
         embedded = self.embed(symbol)
-        # -> 1 x B x decoder_dim.
-        # Get the index of the last unmasked tensor.
-        # -> B.
-        last_encoder_out_idxs = (~encoder_mask).sum(dim=1) - 1
-        # -> B x 1 x 1.
-        last_encoder_out_idxs = last_encoder_out_idxs.view(
-            encoder_out.size(0), 1, 1
-        )
-        # -> 1 x 1 x encoder_dim. This indexes the last non-padded dimension.
-        last_encoder_out_idxs = last_encoder_out_idxs.expand(
-            -1, -1, encoder_out.size(-1)
-        )
-        # -> B x 1 x encoder_dim.
-        last_encoder_out = torch.gather(encoder_out, 1, last_encoder_out_idxs)
-        # The input to decoder RNN is the embedding concatenated to the
-        # weighted, encoded, inputs.
-        output, hiddens = self.module(
-            torch.cat((embedded, last_encoder_out), 2), last_hiddens
-        )
+        last_encoder_out = self._last_encoder_out(encoder_out, encoder_mask)
+        decoder_input = torch.cat((embedded, last_encoder_out), dim=2)
+        output, hiddens = self.module(decoder_input, last_hiddens)
         output = self.dropout_layer(output)
         return base.ModuleOutput(output, hiddens)
+
+    @staticmethod
+    def _last_encoder_out(
+        encoder_out: torch.Tensor, encoder_mask: torch.Tensor
+    ) -> torch.Tensor:
+        """Gets the encoding at the first END for each tensor.
+
+        Args:
+            encoder_out (torch.Tensor): encoded input sequence of shape
+                B x seq_len x target_vocab_size.
+            encoder_mask (torch.Tensor): mask for the encoded input batch of
+                shape B x seq_len.
+
+        Returns:
+            torch.Tensor: indices of shape B x 1 x target_vocab_size.
+        """
+        # Gets the index of the last unmasked tensor.
+        # -> B.
+        last_idx = (~encoder_mask).sum(dim=1) - 1
+        # -> B x 1 x target_vocab_size.
+        last_idx = last_idx.view(encoder_out.size(0), 1, 1).expand(
+            -1, -1, encoder_out.size(2)
+        )
+        # -> B x 1 x encoder_dim.
+        return encoder_out.gather(1, last_idx)
 
     @property
     def output_size(self) -> int:
@@ -206,7 +219,11 @@ class LSTMDecoder(RNNDecoder):
 
 
 class AttentiveRNNDecoder(RNNDecoder):
-    """Abstract base class for attentive RNN decoders."""
+    """Abstract base class for attentive RNN decoders.
+
+    Subsequent concrete implementations use the attention module to
+    differentially attend to different parts of the encoder output.
+    """
 
     def __init__(self, attention_input_size, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -232,7 +249,7 @@ class AttentiveGRUDecoder(AttentiveRNNDecoder, GRUDecoder):
             last_hiddens (torch.Tensor): last hidden states from the decoder
                 of shape 1 x B x decoder_dim.
             encoder_out (torch.Tensor): encoded input sequence of shape
-                B x seq_len x encoder_dim.
+                B x seq_len x target_vocab_size.
             encoder_mask (torch.Tensor): mask for the encoded input batch of
                 shape B x seq_len.
 
@@ -244,9 +261,8 @@ class AttentiveGRUDecoder(AttentiveRNNDecoder, GRUDecoder):
         context, _ = self.attention(
             last_hiddens.transpose(0, 1), encoder_out, encoder_mask
         )
-        output, hiddens = self.module(
-            torch.cat((embedded, context), 2), last_hiddens
-        )
+        decoder_input = torch.cat((embedded, context), dim=2)
+        output, hiddens = self.module(decoder_input, last_hiddens)
         output = self.dropout_layer(output)
         return base.ModuleOutput(output, hiddens)
 
@@ -272,7 +288,7 @@ class AttentiveLSTMDecoder(AttentiveRNNDecoder, LSTMDecoder):
             last_hiddens (Tuple[torch.Tensor, torch.Tensor]): last hidden
                 and cell state from the decoder of shape 1 x B x decoder_dim.
             encoder_out (torch.Tensor): encoded input sequence of shape
-                B x seq_len x encoder_dim.
+                B x seq_len x target_vocab_size.
             encoder_mask (torch.Tensor): mask for the encoded input batch of
                 shape B x seq_len.
 
@@ -280,16 +296,14 @@ class AttentiveLSTMDecoder(AttentiveRNNDecoder, LSTMDecoder):
             base.ModuleOutput: decoder output, and the previous hidden states
                 from the decoder RNN.
         """
-        # The last hiddens includes the cell state, which isn't needed for the
-        # forward pass.
         embedded = self.embed(symbol)
-        last_h0, last_c0 = last_hiddens
+        # Cell state isn't needed for the forward pass.
+        last_h0, _ = last_hiddens
         context, _ = self.attention(
             last_h0.transpose(0, 1), encoder_out, encoder_mask
         )
-        output, hiddens = self.module(
-            torch.cat((embedded, context), 2), last_hiddens
-        )
+        decoder_input = torch.cat((embedded, context), dim=2)
+        output, hiddens = self.module(decoder_input, last_hiddens)
         output = self.dropout_layer(output)
         return base.ModuleOutput(output, hiddens)
 

--- a/yoyodyne/models/modules/rnn.py
+++ b/yoyodyne/models/modules/rnn.py
@@ -31,12 +31,12 @@ class RNNModule(base.BaseModule):
         self.bidirectional = bidirectional
         self.module = self.get_module()
 
+    @abc.abstractmethod
+    def get_module(self) -> nn.RNNBase: ...
+
     @property
     def num_directions(self) -> int:
         return 2 if self.bidirectional else 1
-
-    @abc.abstractmethod
-    def get_module(self) -> nn.RNNBase: ...
 
 
 class RNNEncoder(RNNModule):

--- a/yoyodyne/models/modules/rnn.py
+++ b/yoyodyne/models/modules/rnn.py
@@ -137,7 +137,7 @@ class RNNDecoder(RNNModule):
                 torch.Tensor]]): last hidden states from the decoder of shape
                 1 x B x decoder_dim.
             encoder_out (torch.Tensor): encoded input sequence of shape
-                B x seq_len x target_vocab_size.
+                B x seq_len x encoder_dim.
             encoder_mask (torch.Tensor): mask for the encoded input batch of
                 shape B x seq_len.
 
@@ -160,17 +160,17 @@ class RNNDecoder(RNNModule):
 
         Args:
             encoder_out (torch.Tensor): encoded input sequence of shape
-                B x seq_len x target_vocab_size.
+                B x seq_len x encoder_dim.
             encoder_mask (torch.Tensor): mask for the encoded input batch of
                 shape B x seq_len.
 
         Returns:
-            torch.Tensor: indices of shape B x 1 x target_vocab_size.
+            torch.Tensor: indices of shape B x 1 x encoder_dim.
         """
         # Gets the index of the last unmasked tensor.
         # -> B.
         last_idx = (~encoder_mask).sum(dim=1) - 1
-        # -> B x 1 x target_vocab_size.
+        # -> B x 1 x encoder_dim.
         last_idx = last_idx.view(encoder_out.size(0), 1, 1).expand(
             -1, -1, encoder_out.size(2)
         )
@@ -249,7 +249,7 @@ class AttentiveGRUDecoder(AttentiveRNNDecoder, GRUDecoder):
             last_hiddens (torch.Tensor): last hidden states from the decoder
                 of shape 1 x B x decoder_dim.
             encoder_out (torch.Tensor): encoded input sequence of shape
-                B x seq_len x target_vocab_size.
+                B x seq_len x encoder_dim.
             encoder_mask (torch.Tensor): mask for the encoded input batch of
                 shape B x seq_len.
 
@@ -288,7 +288,7 @@ class AttentiveLSTMDecoder(AttentiveRNNDecoder, LSTMDecoder):
             last_hiddens (Tuple[torch.Tensor, torch.Tensor]): last hidden
                 and cell state from the decoder of shape 1 x B x decoder_dim.
             encoder_out (torch.Tensor): encoded input sequence of shape
-                B x seq_len x target_vocab_size.
+                B x seq_len x encoder_dim.
             encoder_mask (torch.Tensor): mask for the encoded input batch of
                 shape B x seq_len.
 

--- a/yoyodyne/models/modules/transformer.py
+++ b/yoyodyne/models/modules/transformer.py
@@ -1,5 +1,6 @@
 """Transformer module classes."""
 
+import abc
 from typing import List, Optional, Tuple
 
 import numpy
@@ -114,7 +115,7 @@ class AttentionOutput:
 
 
 class TransformerModule(base.BaseModule):
-    """Base module for transformer.
+    """Abstract base module for transformers.
 
     Args:
         *args: passed to superclass.
@@ -165,9 +166,12 @@ class TransformerModule(base.BaseModule):
         positional_embedding = self.positional_encoding(symbols)
         return self.dropout_layer(word_embedding + positional_embedding)
 
+    @abc.abstractmethod
+    def get_module(self) -> base.BaseModule: ...
+
 
 class TransformerEncoder(TransformerModule):
-    """Ordinary transformer encoder.
+    """Transformer encoder.
 
     Our implementation uses "pre-norm", i.e., it applies layer normalization
     before attention. Because of this, we are not currently able to make use
@@ -214,12 +218,12 @@ class TransformerEncoder(TransformerModule):
         )
 
     @property
-    def output_size(self) -> int:
-        return self.embedding_size
-
-    @property
     def name(self) -> str:
         return "transformer"
+
+    @property
+    def output_size(self) -> int:
+        return self.embedding_size
 
 
 class FeatureInvariantTransformerEncoder(TransformerEncoder):
@@ -461,7 +465,7 @@ class TransformerDecoderLayerSeparateFeatures(nn.TransformerDecoderLayer):
 
 
 class TransformerDecoderSeparateFeatures(nn.TransformerDecoder):
-    """A transformer decoder with separate features.
+    """Transformer decoder with separate features.
 
     Adding separate features into the transformer stack is implemented with
     TransformerDecoderLayerseparateFeatures layers.
@@ -518,7 +522,7 @@ class TransformerDecoderSeparateFeatures(nn.TransformerDecoder):
 
 
 class TransformerDecoder(TransformerModule):
-    """A transformer decoder."""
+    """Transformer decoder."""
 
     # Output arg.
     decoder_input_size: int
@@ -597,12 +601,12 @@ class TransformerDecoder(TransformerModule):
         )
 
     @property
-    def output_size(self) -> int:
-        return self.num_embeddings
-
-    @property
     def name(self) -> str:
         return "transformer"
+
+    @property
+    def output_size(self) -> int:
+        return self.num_embeddings
 
 
 class TransformerPointerDecoder(TransformerDecoder):

--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -16,9 +16,10 @@ class RNNModel(base.BaseModel):
     """Abstract base class for RNN models.
 
     The implementation of `get_decoder` in the derived classes determines not
-    just what kind of RNN is used (i.e., GRU or LSTM), but also whether this
-    is an this is "inattentive"---in which case last (non-padding) hidden state
-    of the encoder is the input to the decoder---or attentive.
+    just what kind of RNN is used (i.e., GRU or LSTM), and this decoder
+    implementation also determines whether this is inattentive---in which
+    case last (non-padding) hidden state of the encoder is the input to the
+    decoder---or attentive.
     """
 
     # Constructed inside __init__.

--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -1,5 +1,6 @@
 """RNN model classes."""
 
+import abc
 import argparse
 import heapq
 from typing import Optional, Tuple, Union
@@ -12,10 +13,12 @@ from . import base, embeddings, modules
 
 
 class RNNModel(base.BaseModel):
-    """Base class for RNN models.
+    """Abstract base class for RNN models.
 
-    In lieu of attention, we concatenate the last (non-padding) hidden state of
-    the encoder to the decoder hidden state.
+    The implementation of `get_decoder` in the derived classes determines not
+    just what kind of RNN is used (i.e., GRU or LSTM), but also whether this
+    is an this is "inattentive"---in which case last (non-padding) hidden state
+    of the encoder is the input to the decoder---or attentive.
     """
 
     # Constructed inside __init__.
@@ -27,31 +30,29 @@ class RNNModel(base.BaseModel):
         self.classifier = nn.Linear(self.hidden_size, self.target_vocab_size)
         self.h0 = nn.Parameter(torch.rand(self.hidden_size))
 
-    def init_embeddings(
-        self,
-        num_embeddings: int,
-        embedding_size: int,
-    ) -> nn.Embedding:
-        """Initializes the embedding layer.
-
-        Args:
-            num_embeddings (int): number of embeddings.
-            embedding_size (int): dimension of embeddings.
-
-        Returns:
-            nn.Embedding: embedding layer.
-        """
-        return embeddings.normal_embedding(num_embeddings, embedding_size)
-
     def beam_decode(
         self,
         encoder_out: torch.Tensor,
         encoder_mask: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Overrides `beam_decode` in `BaseEncoderDecoder`.
+        """Decodes with a beam.
 
-        This method implements the LSTM-specific beam search version. Note
-        that we assume batch size is 1.
+        Args:
+            encoder_out (torch.Tensor): batch of encoded input symbols.
+            encoder_mask (torch.Tensor): mask for the batch of encoded
+                input symbols.
+
+        Decoding halts once all sequences in a batch have reached END. It is
+        not currently possible to combine this with loss computation or
+        teacher forcing.
+
+        The implementation assumes batch size is 1, but both inputs and outputs
+        are assumed to have a leading dimension representing batch size.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: predictions of shape
+                B x beam_size x seq_length and log-likelihoods of shape
+                B x beam_size.
         """
         # TODO: modify to work with batches larger than 1.
         batch_size = encoder_mask.size(0)
@@ -91,7 +92,10 @@ class RNNModel(base.BaseModel):
                     device=self.device,
                 ).unsqueeze(1)
                 decoded = self.decoder(
-                    decoder_input, decoder_hiddens, encoder_out, encoder_mask
+                    decoder_input,
+                    decoder_hiddens,
+                    encoder_out,
+                    encoder_mask,
                 )
                 logits = self.classifier(decoded.output)
                 likelihoods.append(
@@ -154,81 +158,6 @@ class RNNModel(base.BaseModel):
         scores = torch.tensor([h[0] for h in histories]).unsqueeze(0)
         return predictions, scores
 
-    def greedy_decode(
-        self,
-        encoder_out: torch.Tensor,
-        encoder_mask: torch.Tensor,
-        teacher_forcing: bool,
-        target: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        """Decodes a sequence given the encoded input.
-
-        Decodes until all sequences in a batch have reached END up to a
-        specified length depending on the `target` args.
-
-        Args:
-            encoder_out (torch.Tensor): batch of encoded input symbols.
-            encoder_mask (torch.Tensor): mask for the batch of encoded
-                input symbols.
-            teacher_forcing (bool): Whether or not to decode
-                with teacher forcing.
-            target (torch.Tensor, optional): target symbols;  we
-                decode up to `len(target)` symbols. If None, we decode up to
-                `self.max_target_length` symbols.
-
-        Returns:
-            torch.Tensor: tensor of predictions of shape seq_len x
-                batch_size x target_vocab_size.
-        """
-        batch_size = encoder_mask.size(0)
-        # Initializes hidden states for decoder LSTM.
-        decoder_hiddens = self.init_hiddens(batch_size)
-        # Feed in the first decoder input, as a start tag.
-        # -> B x 1.
-        decoder_input = (
-            torch.tensor([special.START_IDX], device=self.device)
-            .repeat(batch_size)
-            .unsqueeze(1)
-        )
-        predictions = []
-        num_steps = (
-            target.size(1) if target is not None else self.max_target_length
-        )
-        # Tracks when each sequence has decoded an END.
-        finished = torch.zeros(batch_size, device=self.device)
-        for t in range(num_steps):
-            # pred: B x 1 x output_size.
-            decoded = self.decoder(
-                decoder_input, decoder_hiddens, encoder_out, encoder_mask
-            )
-            decoder_output, decoder_hiddens = decoded.output, decoded.hiddens
-            logits = self.classifier(decoder_output)
-            predictions.append(logits.squeeze(1))
-            # In teacher forcing mode the next input is the gold symbol
-            # for this step.
-            if teacher_forcing:
-                decoder_input = target[:, t].unsqueeze(1)
-            # Otherwise we pass the top pred to the next timestep
-            # (i.e., student forcing, greedy decoding).
-            else:
-                decoder_input = self._get_predicted(logits)
-                # Updates to track which sequences have decoded an END.
-                finished = torch.logical_or(
-                    finished, (decoder_input == special.END_IDX)
-                )
-                # Breaks when all sequences have predicted an END symbol. If we
-                # have a target (and are thus computing loss), we only break
-                # when we have decoded at least the the same number of steps as
-                # the target length.
-                if finished.all():
-                    if target is None or decoder_input.size(-1) >= target.size(
-                        -1
-                    ):
-                        break
-        # -> B x seq_len x target_vocab_size.
-        predictions = torch.stack(predictions, dim=1)
-        return predictions
-
     def forward(
         self,
         batch: data.PaddedBatch,
@@ -241,11 +170,11 @@ class RNNModel(base.BaseModel):
         Returns:
             Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]: beam
                 search returns a tuple with a tensor of predictions of shape
-                B x beam_width x seq_len and a tensor of shape beam_width with
-                the likelihood (the unnormalized sum of sequence
+                B x beam_width x seq_len and a tensor of B x shape beam_width
+                with the likelihood (the unnormalized sum of sequence
                 log-probabilities) for each prediction; greedy search returns
                 a tensor of predictions of shape
-                B x target_vocab_size x seq_len.
+                B x seq_len x target_vocab_size.
         """
         encoder_out = self.source_encoder(batch.source).output
         # This function has a polymorphic return because beam search needs to
@@ -262,39 +191,112 @@ class RNNModel(base.BaseModel):
                 batch.target.padded if batch.target else None,
             )
 
-    @staticmethod
-    def add_argparse_args(parser: argparse.ArgumentParser) -> None:
-        """Adds RNN configuration options to the argument parser.
+    @abc.abstractmethod
+    def get_decoder(self) -> modules.BaseModule: ...
+
+    def greedy_decode(
+        self,
+        encoder_out: torch.Tensor,
+        encoder_mask: torch.Tensor,
+        teacher_forcing: bool,
+        target: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Decodes greedily.
+
+        A hard upper bound on the length of the decoded strings is provided by
+        the length of the target strings (more specifically, the length of the
+        longest target string) if a target is provided, or `max_target_length`
+        if not. Decoding will halt earlier if no target is provided and all
+        sequences have reached END.
 
         Args:
-            parser (argparse.ArgumentParser).
+            encoder_out (torch.Tensor): batch of encoded input symbols.
+            encoder_mask (torch.Tensor): mask for the batch of encoded
+                input symbols.
+            teacher_forcing (bool): whether or not to decode with teacher
+                forcing.
+            target (torch.Tensor, optional): target symbols; if provided this
+                decoding continues until this length is reached.
+
+        Returns:
+            torch.Tensor: predictions of B x seq_length x target_vocab_size.
         """
-        parser.add_argument(
-            "--bidirectional",
-            action="store_true",
-            default=defaults.BIDIRECTIONAL,
-            help="Uses a bidirectional encoder (RNN-backed architectures "
-            "only. Default: enabled.",
+        batch_size = encoder_mask.size(0)
+        # Initializes hidden states for decoder LSTM.
+        decoder_hiddens = self.init_hiddens(batch_size)
+        decoder_input = (
+            torch.tensor([special.START_IDX], device=self.device)
+            .repeat(batch_size)
+            .unsqueeze(1)
         )
-        parser.add_argument(
-            "--no_bidirectional",
-            action="store_false",
-            dest="bidirectional",
-        )
+        predictions = []
+        if target is None:
+            max_num_steps = self.max_target_length
+            # Tracks when each sequence has decoded an END.
+            finished = torch.zeros(batch_size, device=self.device)
+        else:
+            max_num_steps = target.size(1)
+        for t in range(max_num_steps):
+            # pred: B x 1 x output_size.
+            decoded = self.decoder(
+                decoder_input,
+                decoder_hiddens,
+                encoder_out,
+                encoder_mask,
+            )
+            decoder_output, decoder_hiddens = (
+                decoded.output,
+                decoded.hiddens,
+            )
+            logits = self.classifier(decoder_output)
+            predictions.append(logits.squeeze(1))
+            if teacher_forcing:
+                # Under teacher forcing the next input is the gold symbol for
+                # this step.
+                decoder_input = target[:, t].unsqueeze(1)
+            else:
+                # Otherwise, under student forcing, the next input is the top
+                # prediction.
+                decoder_input = self._get_predicted(logits)
+            if target is None:
+                # Updates which sequences have decoded an END.
+                finished = torch.logical_or(
+                    finished, (decoder_input == special.END_IDX)
+                )
+                if finished.all():
+                    break
+        # -> B x seq_len x target_vocab_size.
+        predictions = torch.stack(predictions, dim=1)
+        return predictions
 
-    def get_decoder(self):
-        raise NotImplementedError
+    def init_embeddings(
+        self,
+        num_embeddings: int,
+        embedding_size: int,
+    ) -> nn.Embedding:
+        """Initializes the embedding layer.
 
-    def init_hiddens(self, batch_size: int):
-        raise NotImplementedError
+        Args:
+            num_embeddings (int): number of embeddings.
+            embedding_size (int): dimension of embeddings.
+
+        Returns:
+            nn.Embedding: embedding layer.
+        """
+        return embeddings.normal_embedding(num_embeddings, embedding_size)
+
+    @abc.abstractmethod
+    def init_hiddens(
+        self, batch_size: int
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]: ...
 
     @property
-    def name(self) -> str:
-        raise NotImplementedError
+    @abc.abstractmethod
+    def name(self) -> str: ...
 
 
 class GRUModel(RNNModel):
-    """GRU encoder-decoder without attention."""
+    """GRU model without attention."""
 
     def get_decoder(self) -> modules.GRUDecoder:
         return modules.GRUDecoder(
@@ -327,7 +329,7 @@ class GRUModel(RNNModel):
 
 
 class LSTMModel(RNNModel):
-    """LSTM encoder-decoder without attention.
+    """LSTM model without attention.
 
     Args:
         *args: passed to superclass.
@@ -353,7 +355,9 @@ class LSTMModel(RNNModel):
             num_embeddings=self.vocab_size,
         )
 
-    def init_hiddens(self, batch_size: int) -> torch.Tensor:
+    def init_hiddens(
+        self, batch_size: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Initializes the hidden state to pass to the RNN.
 
         We treat the initial value as a model parameter.
@@ -375,7 +379,7 @@ class LSTMModel(RNNModel):
 
 
 class AttentiveGRUModel(GRUModel):
-    """GRU encoder-decoder with attention."""
+    """GRU model with attention."""
 
     def get_decoder(self) -> modules.AttentiveGRUDecoder:
         return modules.AttentiveGRUDecoder(
@@ -396,7 +400,7 @@ class AttentiveGRUModel(GRUModel):
 
 
 class AttentiveLSTMModel(LSTMModel):
-    """LSTM encoder-decoder with attention."""
+    """LSTM model with attention."""
 
     def get_decoder(self) -> modules.AttentiveLSTMDecoder:
         return modules.AttentiveLSTMDecoder(
@@ -414,3 +418,23 @@ class AttentiveLSTMModel(LSTMModel):
     @property
     def name(self) -> str:
         return "attentive LSTM"
+
+
+def add_argparse_args(parser: argparse.ArgumentParser) -> None:
+    """Adds RNN configuration options to the argument parser.
+
+    Args:
+        parser (argparse.ArgumentParser).
+    """
+    parser.add_argument(
+        "--bidirectional",
+        action="store_true",
+        default=defaults.BIDIRECTIONAL,
+        help="Uses a bidirectional encoder (RNN-backed architectures "
+        "only. Default: enabled.",
+    )
+    parser.add_argument(
+        "--no_bidirectional",
+        action="store_false",
+        dest="bidirectional",
+    )

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -72,8 +72,7 @@ class TransducerRNNModel(rnn.RNNModel):
     ) -> Tuple[List[List[int]], torch.Tensor]: ...
 
     @abc.abstractmethod
-    def get_decoder(self):
-        modules.RNNDecoder: ...
+    def get_decoder(self) -> modules.RNNDecoder: ...
 
     def greedy_decode(
         self,

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -74,7 +74,7 @@ class TransformerModel(base.BaseModel):
         """
         if self.training and self.teacher_forcing:
             assert (
-                batch.target.padded is not None
+                batch.has_target
             ), "Teacher forcing requested but no target provided"
             # Initializes the start symbol for decoding.
             starts = (

--- a/yoyodyne/predict.py
+++ b/yoyodyne/predict.py
@@ -134,6 +134,9 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
     Args:
         parser (argparse.ArgumentParser).
     """
+    data.add_argparse_args(parser)
+    lightning.Trainer.add_argparse_args(parser)
+    models.add_argparse_args(parser)
     # Path arguments.
     parser.add_argument(
         "--checkpoint",
@@ -155,15 +158,13 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         required=True,
         help="Path to prediction output data TSV.",
     )
-    # Data arguments.
-    data.add_argparse_args(parser)
-    # Architecture arguments; the architecture-specific ones are not needed.
-    models.add_argparse_args(parser)
-    models.BaseModel.add_predict_argparse_args(parser)
-    # Among the things this adds, the following are likely to be useful:
-    # --accelerator ("gpu" for GPU)
-    # --devices (for multiple device support)
-    lightning.Trainer.add_argparse_args(parser)
+    # Other prediction arguments.
+    parser.add_argument(
+        "--beam_width",
+        type=int,
+        required=False,
+        help="Size of the beam for beam search. Default: %(default)s.",
+    )
 
 
 def main() -> None:

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -336,11 +336,11 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
     """
     data.add_argparse_args(parser)
     evaluators.add_argparse_args(parser)
-    lightning.Trainer.add_argparse_args(parser)
     metrics.add_argparse_args(parser)
     models.add_argparse_args(parser)
     schedulers.add_argparse_args(parser)
     sizing.add_argparse_args(parser)
+    lightning.Trainer.add_argparse_args(parser)
     # Path arguments.
     parser.add_argument(
         "--model_dir",

--- a/yoyodyne/train.py
+++ b/yoyodyne/train.py
@@ -334,6 +334,13 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
     Args:
         argparse.ArgumentParser.
     """
+    data.add_argparse_args(parser)
+    evaluators.add_argparse_args(parser)
+    lightning.Trainer.add_argparse_args(parser)
+    metrics.add_argparse_args(parser)
+    models.add_argparse_args(parser)
+    schedulers.add_argparse_args(parser)
+    sizing.add_argparse_args(parser)
     # Path arguments.
     parser.add_argument(
         "--model_dir",
@@ -381,30 +388,6 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
         action="store_false",
         dest="log_wandb",
     )
-    data.add_argparse_args(parser)
-    evaluators.add_argparse_args(parser)
-    metrics.add_argparse_args(parser)
-    models.add_argparse_args(parser)
-    models.expert.add_argparse_args(parser)
-    models.modules.add_argparse_args(parser)
-    models.BaseModel.add_argparse_args(parser)
-    models.HardAttentionRNNModel.add_argparse_args(parser)
-    models.RNNModel.add_argparse_args(parser)
-    models.TransformerModel.add_argparse_args(parser)
-    schedulers.add_argparse_args(parser)
-    sizing.add_argparse_args(parser)
-    # Trainer arguments.
-    # Among the things this adds, the following are likely to be useful:
-    # --accelerator ("gpu" for GPU)
-    # --check_val_every_n_epoch
-    # --devices (for multiple device support)
-    # --gradient_clip_val
-    # --max_epochs
-    # --min_epochs
-    # --max_steps
-    # --min_steps
-    # --max_time
-    lightning.Trainer.add_argparse_args(parser)
 
 
 def main() -> None:


### PR DESCRIPTION
PEP 3119 introduced decorators for declaring abstract methods. This PR uses them throughout the model, module, and evaluator hierarchies.

This is definitely superior to what we did before #254, which was to just declare but not implement these. Since that's the same as having a no-op null-return function, an unimplemented method in a concrete class just returns `None`. Usually, this will trigger failures somewhere downstream at run-time but the errors are completely uninformative and hard to trace down.

In #254, which added GRU support, I changed these to raise `NotImplementedError`. This means we get a fatal error (assuming we've wrapped things in an overly-general `try`/`except`) when the methods are called. 

With PEP 3119, we make `BaseModel`, `BaseModule`, etc. inherit (directly) from `abc.ABC` and then decorate methods that concrete classes must implement with `@abc.abstractmethod` (etc.). Then, Python gives an informative error when you attempt to instantiate a class which you thought was concrete but which in fact is abstract, and tells you the name of the method which hasn't been implemented. This is also "runtime" but happens at construction time and the error message is better. To review what this actually looks like, I recommend reading included commit [`ac8234f0ed0698e70adf0b86e95311156723b1f5`](https://github.com/kylebgorman/yoyodyne/commit/ac8234f0ed0698e70adf0b86e95311156723b1f5).

To actually track down the methods, I also imposed the following cleanups:

* Instead of using a static method to add args to the parser, I moved this to the module level, which cleans up things a bit. 
* I reordered methods roughly alphabetically; helper methods were made `_protected` (most already were) and are listed right after the methods(s) which call them. This is the recommendation from the "Clean Code" people and it helped me find all the missing pieces.