### PR TITLE
Audits dropout layers

### DIFF
--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -108,7 +108,6 @@ class BaseModel(lightning.LightningModule):
         self.embeddings = self.init_embeddings(
             self.vocab_size, self.embedding_size
         )
-        self.dropout_layer = nn.Dropout(p=self.dropout, inplace=False)
         self.evaluators = [
             evaluators.get_evaluator(eval_metric)()
             for eval_metric in self.eval_metrics

--- a/yoyodyne/models/modules/base.py
+++ b/yoyodyne/models/modules/base.py
@@ -60,7 +60,7 @@ class BaseModule(lightning.LightningModule):
         self.num_embeddings = num_embeddings
         self.layers = layers
         self.hidden_size = hidden_size
-        self.dropout_layer = nn.Dropout(p=self.dropout, inplace=False)
+        self.dropout_layer = nn.Dropout(p=self.dropout, inplace=True)
 
     def embed(self, symbols: torch.Tensor) -> torch.Tensor:
         """Embeds the source symbols and adds positional encodings.
@@ -73,7 +73,8 @@ class BaseModule(lightning.LightningModule):
             torch.Tensor: embedded tensor of shape B x seq_len x embed_dim.
         """
         embedded = self.embeddings(symbols)
-        return self.dropout_layer(embedded)
+        self.dropout_layer(embedded)
+        return embedded
 
     @property
     def output_size(self) -> int:

--- a/yoyodyne/models/modules/rnn.py
+++ b/yoyodyne/models/modules/rnn.py
@@ -164,7 +164,7 @@ class RNNDecoder(RNNModule):
         output, hiddens = self.module(
             torch.cat((embedded, last_encoder_out), 2), last_hiddens
         )
-        output = self.dropout_layer(output)
+        self.dropout_layer(output)
         return base.ModuleOutput(output, hiddens)
 
     @property
@@ -250,7 +250,7 @@ class AttentiveGRUDecoder(AttentiveRNNDecoder, GRUDecoder):
         output, hiddens = self.module(
             torch.cat((embedded, context), 2), last_hiddens
         )
-        output = self.dropout_layer(output)
+        self.dropout_layer(output)
         return base.ModuleOutput(output, hiddens)
 
     @property
@@ -293,7 +293,7 @@ class AttentiveLSTMDecoder(AttentiveRNNDecoder, LSTMDecoder):
         output, hiddens = self.module(
             torch.cat((embedded, context), 2), last_hiddens
         )
-        output = self.dropout_layer(output)
+        self.dropout_layer(output)
         return base.ModuleOutput(output, hiddens)
 
     @property

--- a/yoyodyne/models/modules/transformer.py
+++ b/yoyodyne/models/modules/transformer.py
@@ -161,9 +161,11 @@ class TransformerModule(base.BaseModule):
             embedded (torch.Tensor): embedded tensor of shape
                 B x seq_len x embed_dim.
         """
-        word_embedding = self.esq * self.embeddings(symbols)
-        positional_embedding = self.positional_encoding(symbols)
-        return self.dropout_layer(word_embedding + positional_embedding)
+        word_embedded = self.esq * self.embeddings(symbols)
+        positional_embedded = self.positional_encoding(symbols)
+        embedded = word_embedded + positional_embedded
+        self.dropout_layer(embedded)
+        return embedded
 
 
 class TransformerEncoder(TransformerModule):
@@ -264,14 +266,12 @@ class FeatureInvariantTransformerEncoder(TransformerEncoder):
         char_mask = (
             symbols < (self.num_embeddings - self.features_vocab_size)
         ).long()
-        type_embedding = self.esq * self.type_embedding(char_mask)
-        word_embedding = self.esq * self.embeddings(symbols)
-        positional_embedding = self.positional_encoding(
-            symbols, mask=char_mask
-        )
-        return self.dropout_layer(
-            word_embedding + positional_embedding + type_embedding
-        )
+        word_embedded = self.esq * self.embeddings(symbols)
+        type_embedded = self.esq * self.type_embedding(char_mask)
+        positional_embedded = self.positional_encoding(symbols, mask=char_mask)
+        embedded = word_embedded + type_embedded + positional_embedded
+        self.dropout_layer(embedded)
+        return embedded
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
# Redundancy

Both base model and base module have a dropout layer, but the base model's dropout is unused. I remove it. We still pass the dropout probability to the modules, of course.

# In-place operation

The base module dropout is defined as an out-of-place operation, but there are several places where we do:

```python
self.dropout_layer = nn.Dropout(..., inplace=False)
...
output = ...
output = self.dropout_layer(output)
```

Knowing what I know about Python internals this is pretty expensive:

* The RHS of the final expression to be computed before the assignment, so we temporarily have two copies of `output` (one dropped out, one not) in memory.
 * This also "thrashes" the GC a bit: it has to deallocate the first one (its reference count will become zero after the reassignment) to clean up the mess.

In contrast:

```python
self.dropout_layer = nn.Dropout(..., inplace=True)
...
output = ...
self.dropout_layer(output)
```

uses half as much memory and doesn't exercise the GC either. Note that there are cases in the transformer where I now have to assign a variable to the combined embedding before dropping out, but that was happening implicitly at variable binding anyways and the new approach does not require any extra storage (plus it's mildly documentary).