### PR TITLE
Reverts use of in-place dropout

### DIFF
--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -58,10 +58,9 @@ class BaseModel(abc.ABC, lightning.LightningModule):
     features_encoder_cls: Optional[modules.base.BaseModule]
     hidden_size: int
     source_encoder_cls: modules.base.BaseModule
-    # Constructed inside __init__.
-    dropout_layer: nn.Dropout
+    # Other stuff.
     eval_metrics: Set[evaluators.Evaluator]
-    loss: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+    loss_func: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
     def __init__(
         self,

--- a/yoyodyne/models/modules/base.py
+++ b/yoyodyne/models/modules/base.py
@@ -63,7 +63,7 @@ class BaseModule(abc.ABC, lightning.LightningModule):
         self.num_embeddings = num_embeddings
         self.layers = layers
         self.hidden_size = hidden_size
-        self.dropout_layer = nn.Dropout(p=self.dropout, inplace=True)
+        self.dropout_layer = nn.Dropout(p=self.dropout)
 
     def embed(self, symbols: torch.Tensor) -> torch.Tensor:
         """Embeds the source symbols and adds positional encodings.
@@ -75,9 +75,7 @@ class BaseModule(abc.ABC, lightning.LightningModule):
         Returns:
             torch.Tensor: embedded tensor of shape B x seq_len x embed_dim.
         """
-        embedded = self.embeddings(symbols)
-        self.dropout_layer(embedded)
-        return embedded
+        return self.dropout_layer(self.embeddings(symbols))
 
     @property
     @abc.abstractmethod

--- a/yoyodyne/models/modules/rnn.py
+++ b/yoyodyne/models/modules/rnn.py
@@ -149,8 +149,7 @@ class RNNDecoder(RNNModule):
         last_encoder_out = self._last_encoder_out(encoder_out, encoder_mask)
         decoder_input = torch.cat((embedded, last_encoder_out), dim=2)
         output, hiddens = self.module(decoder_input, last_hiddens)
-        self.dropout_layer(output)
-        return base.ModuleOutput(output, hiddens)
+        return base.ModuleOutput(self.dropout_layer(output), hiddens)
 
     @staticmethod
     def _last_encoder_out(
@@ -263,8 +262,7 @@ class AttentiveGRUDecoder(AttentiveRNNDecoder, GRUDecoder):
         )
         decoder_input = torch.cat((embedded, context), dim=2)
         output, hiddens = self.module(decoder_input, last_hiddens)
-        self.dropout_layer(output)
-        return base.ModuleOutput(output, hiddens)
+        return base.ModuleOutput(self.dropout_layer(output), hiddens)
 
     @property
     def name(self) -> str:
@@ -304,8 +302,7 @@ class AttentiveLSTMDecoder(AttentiveRNNDecoder, LSTMDecoder):
         )
         decoder_input = torch.cat((embedded, context), dim=2)
         output, hiddens = self.module(decoder_input, last_hiddens)
-        self.dropout_layer(output)
-        return base.ModuleOutput(output, hiddens)
+        return base.ModuleOutput(self.dropout_layer(output), hiddens)
 
     @property
     def name(self) -> str:

--- a/yoyodyne/models/modules/transformer.py
+++ b/yoyodyne/models/modules/transformer.py
@@ -164,9 +164,7 @@ class TransformerModule(base.BaseModule):
         """
         word_embedded = self.esq * self.embeddings(symbols)
         positional_embedded = self.positional_encoding(symbols)
-        embedded = word_embedded + positional_embedded
-        self.dropout_layer(embedded)
-        return embedded
+        return self.dropout_layer(word_embedded + positional_embedded)
 
     @abc.abstractmethod
     def get_module(self) -> base.BaseModule: ...
@@ -273,9 +271,9 @@ class FeatureInvariantTransformerEncoder(TransformerEncoder):
         word_embedded = self.esq * self.embeddings(symbols)
         type_embedded = self.esq * self.type_embedding(char_mask)
         positional_embedded = self.positional_encoding(symbols, mask=char_mask)
-        embedded = word_embedded + type_embedded + positional_embedded
-        self.dropout_layer(embedded)
-        return embedded
+        return self.dropout_layer(
+            word_embedded + type_embedded + positional_embedded
+        )
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
This reverts an earlier change (#293) which added in-place dropout. On my PC (Windows 11, WSL, older Nvidia GPU) in-place dropout throws the inscrutable message:

```
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor [128, 1, 512]], which is output 0 of CudnnRnnBackward0, is at version 1; expected version 0 instead. Hint: enable anomaly detection to find the operation that failed to compute its gradient, with torch.autograd.set_detect_anomaly(True).
```

Tracing down this mysterious tensor of shape 128 x 1 x 512 I found that it was the tensor input to dropout.

Since I didn't see this on my laptop I suspect it is quite literally platform-dependent. 

Note however that I now instead avoid the expensive overwriting operation all the same, so we get most of the same benefits as #293.