### PR TITLE
Avoids 0-to-a-negative exponent error

### DIFF
--- a/yoyodyne/schedulers.py
+++ b/yoyodyne/schedulers.py
@@ -68,7 +68,7 @@ class WarmupInverseSquareRoot(optim.lr_scheduler.LambdaLR):
             # +1 in numerator avoids a zero-LR first step.
             return (step + 1) / self.warmup_steps
         # +1 in base of exponent avoids an undefined operation (0 to a negative
-        # power) in unlikely case one is not using warmup.
+        # exponent) in the unlikely case one is using this without warmup.
         return self.decay_factor * (step + 1)**-0.5
 
     def config_dict(self) -> Dict[str, Any]:

--- a/yoyodyne/schedulers.py
+++ b/yoyodyne/schedulers.py
@@ -65,9 +65,11 @@ class WarmupInverseSquareRoot(optim.lr_scheduler.LambdaLR):
             float: lr_lambda.
         """
         if step < self.warmup_steps:
-            # Adding 1 avoids the case where the initial LR is 0.
-            return (1 + step) / self.warmup_steps
-        return self.decay_factor * step**-0.5
+            # +1 in numerator avoids a zero-LR first step.
+            return (step + 1) / self.warmup_steps
+        # +1 in base of exponent avoids an undefined operation (0 to a negative
+        # power) in unlikely case one is not using warmup.
+        return self.decay_factor * (step + 1)**-0.5
 
     def config_dict(self) -> Dict[str, Any]:
         return {"interval": "step", "frequency": 1}

--- a/yoyodyne/schedulers.py
+++ b/yoyodyne/schedulers.py
@@ -69,7 +69,7 @@ class WarmupInverseSquareRoot(optim.lr_scheduler.LambdaLR):
             return (step + 1) / self.warmup_steps
         # +1 in base of exponent avoids an undefined operation (0 to a negative
         # exponent) in the unlikely case one is using this without warmup.
-        return self.decay_factor * (step + 1)**-0.5
+        return self.decay_factor * (step + 1) ** -0.5
 
     def config_dict(self) -> Dict[str, Any]:
         return {"interval": "step", "frequency": 1}


### PR DESCRIPTION
When using the warmup inverse square root scheduler, if one specifies no warmup, you will hit the following error:

```
    return self.decay_factor * step**-0.5
                               ~~~~^^~~~~
ZeroDivisionError: 0.0 cannot be raised to a negative power
```

This can simply be avoided by treating step as 1-based. We already do this in the warmup clause, so we now do this in the warmed-up clause too. I also slightly improve the comments since this is an important point.