### PR TITLE
Robust subprocess sweep

### DIFF
--- a/examples/wandb_sweeps/sweep.py
+++ b/examples/wandb_sweeps/sweep.py
@@ -1,79 +1,95 @@
 #!/usr/bin/env python
-"""Runs the sweep itself."""
+"""Runs a W&B sweep."""
 
 import argparse
 import functools
+import logging
+import subprocess
 import traceback
 import warnings
 
-import torch
+from typing import List
+
 import wandb
 
-from yoyodyne import train, util
 
 warnings.filterwarnings("ignore", ".*is a wandb run already in progress.*")
 
 
-def train_sweep(args: argparse.Namespace) -> None:
-    """Runs a single training run.
-
-    The wandb config data used here comes from the environment.
+def run(argv: List[str]) -> None:
+    """A single training run.
 
     Args:
-        args (argparse.Namespace).
+        argv (List[str]): partial command-line arguments (the command name
+            plus CLI arguments passed to this script but not declared below).
+    """
+    argv = populate_argv(argv)
+    process = subprocess.Popen(argv, stderr=subprocess.PIPE, text=True)
+    for line in process.stderr:
+        logging.info(line.rstrip())
+    wandb.finish(exit_code=process.wait())
+
+
+def populate_argv(argv: List[str]) -> List[str]:
+    """Populates argv with W&B arguments.
+
+    This copies and mutates to prevent side effects persisting beyond the
+    individual run.
+
+    Args:
+        argv (List[str]): partial command-line arguments (the command name
+            plus CLI arguments passed to this script but not declared below).
+
+    Returns:
+        List[str]: complete command-line arguments populated with W&B run
+            hyperparameters.
     """
     wandb.init()
-    # Model arguments come from the wandb sweep config and override any
-    # conflicting arguments passed via the CLI.
+    result = argv.copy()
     for key, value in wandb.config.items():
-        if key in args:
-            util.log_info(f"Overriding CLI argument: {key}")
-        setattr(args, key, value)
-    try:
-        train.train(args)  # Ignoring return value.
-    except RuntimeError as error:
-        # TODO: consider specializing this further if a solution to
-        # https://github.com/pytorch/pytorch/issues/48365 is accepted.
-        util.log_info(f"Runtime error: {error!s}")
-    finally:
-        # Clears the CUDA cache.
-        torch.cuda.empty_cache()
+        result.append(f"--{key}")
+        if value is not None:
+            result.append(f"{value}")
+    return result
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__)
-    train.add_argparse_args(parser)
-    parser.add_argument(
-        "--sweep_id",
-        required=True,
-        help="ID for the sweep.",
-    )
-    parser.add_argument("--entity", required=True, help="Entity name.")
-    parser.add_argument("--project", required=True, help="Project name.")
-    parser.add_argument(
-        "--count",
-        type=int,
-        help="Number of runs to perform.",
-    )
-    args = parser.parse_args()
-    # Forces log_wandb to True, so that the PTL trainer logs runtime metrics
-    # to wandb.
-    args.log_wandb = True
+def main(args: argparse.Namespace, argv: List[str]) -> None:
+    argv = ["yoyodyne-train", *argv]
     try:
         wandb.agent(
             sweep_id=args.sweep_id,
             entity=args.entity,
             project=args.project,
-            function=functools.partial(train_sweep, args),
+            function=functools.partial(run, argv),
             count=args.count,
         )
     except Exception:
         # Exits gracefully, so wandb logs the error.
-        util.log_info(traceback.format_exc())
+        logging.fatal(traceback.format_exc())
+        wandb.finish(exit_code=1)
         exit(1)
-    finally:
-        wandb.finish()
 
 
 if __name__ == "__main__":
-    main()
+    logging.basicConfig(
+        format="%(levelname)s: %(asctime)s - %(message)s",
+        datefmt="%d-%b-%y %H:%M:%S",
+        level="INFO",
+    )
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sweep_id", required=True, help="ID for the sweep.")
+    parser.add_argument(
+        "--entity", required=True, help="The entity scope for the project."
+    )
+    parser.add_argument(
+        "--project", required=True, help="The project of the sweep."
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        help="Number of runs to perform.",
+    )
+    # We separate out the args declared above, which control the sweep itself,
+    # and all others, which are passed to the subprocess as is.
+    args, argv = parser.parse_known_args()
+    main(args, argv)

--- a/examples/wandb_sweeps/sweep.py
+++ b/examples/wandb_sweeps/sweep.py
@@ -47,14 +47,16 @@ def populate_argv(argv: List[str]) -> List[str]:
     wandb.init()
     result = argv.copy()
     for key, value in wandb.config.items():
+        if value is None:
+            continue
         result.append(f"--{key}")
-        if value is not None:
-            result.append(f"{value}")
+        result.append(f"{value}")
     return result
 
 
 def main(args: argparse.Namespace, argv: List[str]) -> None:
-    argv = ["yoyodyne-train", *argv]
+    # W&B support must be enabled.
+    argv = ["yoyodyne-train", "--log_wandb", *argv]
     try:
         wandb.agent(
             sweep_id=args.sweep_id,


### PR DESCRIPTION
As described in #302, this moves the sweep to a model where each sweep run is a subprocess, which seems likely to ensure the OS returns memory at the end of each run. This model is [one we piloted in UDTube](https://github.com/CUNY-CL/udtube/blob/master/examples/wandb_sweeps/sweep.py) and here the implementation is actually simpler because there's no need for temporary config files.

Testing confirms this works and that the data is being logged as expected to W&B, but I'd appreciate if a reviewer can try it out locally with an existing workflow. 

One nice side effect of this is we no longer need to maintain the `train.train` module interface, which has no place in LightningCLI anyways. 

Closes #302.