### PR TITLE
Always uses learned initialization for pointer-generator

### DIFF
--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -402,9 +402,7 @@ class PointerGeneratorGRUModel(PointerGeneratorRNNModel, rnn.GRUModel):
         """
         encoder_out = self.source_encoder(batch.source)
         source_encoded = encoder_out.output
-        last_hiddens = self.init_hiddens(
-            len(batch), self.source_encoder.layers
-        )
+        last_hiddens = self.init_hiddens(len(batch))
         if not self.has_features_encoder:
             if self.beam_width > 1:
                 # Will raise a NotImplementedError.
@@ -428,9 +426,6 @@ class PointerGeneratorGRUModel(PointerGeneratorRNNModel, rnn.GRUModel):
         else:
             features_encoder_out = self.features_encoder(batch.features)
             features_encoded = features_encoder_out.output
-            last_hiddens = self.init_hiddens(
-                len(batch), self.source_encoder.layers
-            )
             if self.beam_width > 1:
                 # Will raise a NotImplementedError.
                 return self.beam_decode(

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -402,16 +402,9 @@ class PointerGeneratorGRUModel(PointerGeneratorRNNModel, rnn.GRUModel):
         """
         encoder_out = self.source_encoder(batch.source)
         source_encoded = encoder_out.output
-        if encoder_out.has_hiddens:
-            last_hiddens = self._reshape_hiddens(
-                encoder_out.hiddens,
-                self.source_encoder.layers,
-                self.source_encoder.num_directions,
-            )
-        else:
-            last_hiddens = self.init_hiddens(
-                len(batch), self.source_encoder.layers
-            )
+        last_hiddens = self.init_hiddens(
+            len(batch), self.source_encoder.layers
+        )
         if not self.has_features_encoder:
             if self.beam_width > 1:
                 # Will raise a NotImplementedError.
@@ -435,16 +428,9 @@ class PointerGeneratorGRUModel(PointerGeneratorRNNModel, rnn.GRUModel):
         else:
             features_encoder_out = self.features_encoder(batch.features)
             features_encoded = features_encoder_out.output
-            if features_encoder_out.has_hiddens:
-                last_hiddens = self._reshape_hiddens(
-                    features_encoder_out.hiddens,
-                    self.features_encoder.layers,
-                    self.features_encoder.num_directions,
-                )
-            else:
-                last_hiddens = self.init_hiddens(
-                    len(batch), self.source_encoder.layers
-                )
+            last_hiddens = self.init_hiddens(
+                len(batch), self.source_encoder.layers
+            )
             if self.beam_width > 1:
                 # Will raise a NotImplementedError.
                 return self.beam_decode(
@@ -468,14 +454,6 @@ class PointerGeneratorGRUModel(PointerGeneratorRNNModel, rnn.GRUModel):
                     features_mask=batch.features.mask,
                     target=(batch.target.padded if batch.target else None),
                 )
-
-    @staticmethod
-    def _reshape_hiddens(
-        h: torch.Tensor,
-        layers: int,
-        num_directions: int,
-    ) -> torch.Tensor:
-        return h.view(layers, num_directions, h.size(1), h.size(2)).sum(axis=1)
 
     def get_decoder(self) -> modules.AttentiveGRUDecoder:
         return modules.AttentiveGRUDecoder(
@@ -585,16 +563,7 @@ class PointerGeneratorLSTMModel(PointerGeneratorRNNModel, rnn.LSTMModel):
         """
         encoder_out = self.source_encoder(batch.source)
         source_encoded = encoder_out.output
-        if encoder_out.has_hiddens:
-            h_source, c_source = encoder_out.hiddens
-            last_hiddens = self._reshape_hiddens(
-                h_source,
-                c_source,
-                self.source_encoder.layers,
-                self.source_encoder.num_directions,
-            )
-        else:
-            last_hiddens = self.init_hiddens(len(batch))
+        last_hiddens = self.init_hiddens(len(batch))
         if not self.has_features_encoder:
             if self.beam_width > 1:
                 # Will raise a NotImplementedError.
@@ -618,16 +587,6 @@ class PointerGeneratorLSTMModel(PointerGeneratorRNNModel, rnn.LSTMModel):
         else:
             features_encoder_out = self.features_encoder(batch.features)
             features_encoded = features_encoder_out.output
-            if features_encoder_out.has_hiddens:
-                h_features, c_features = features_encoder_out.hiddens
-                h_features, c_features = self._reshape_hiddens(
-                    h_features,
-                    c_features,
-                    self.features_encoder.layers,
-                    self.features_encoder.num_directions,
-                )
-            else:
-                h_features, c_features = self.init_hiddens(len(batch))
             if self.beam_width > 1:
                 # Will raise a NotImplementedError.
                 return self.beam_decode(
@@ -651,17 +610,6 @@ class PointerGeneratorLSTMModel(PointerGeneratorRNNModel, rnn.LSTMModel):
                     features_mask=batch.features.mask,
                     target=(batch.target.padded if batch.target else None),
                 )
-
-    @staticmethod
-    def _reshape_hiddens(
-        h: torch.Tensor,
-        c: torch.Tensor,
-        layers: int,
-        num_directions: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        h = h.view(layers, num_directions, h.size(1), h.size(2)).sum(axis=1)
-        c = c.view(layers, num_directions, c.size(1), c.size(2)).sum(axis=1)
-        return h, c
 
     def get_decoder(self) -> modules.AttentiveLSTMDecoder:
         return modules.AttentiveLSTMDecoder(


### PR DESCRIPTION
The implementation of pointer-generator RNNs contains disjunctions in the `forward` method which determine whether to use the encoder's hidden state as the input to the decoder, or the learned `h0` (and `c0` for LSTMs). We remove the disjucntion and just use the learned ones all the time (cf. #303). 57 lines of code are removed; my tests find no accuracy or latency regressions. 

Closes #304.

This will also support my effort to have less GRU/LSTM-specific code at the `model` level; more coming soon.