### PR TITLE
Raises error with unsupported features encoders

### DIFF
--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -100,7 +100,7 @@ class HardAttentionRNNModel(rnn.RNNModel):
     def beam_decode(self, *args, **kwargs):
         """Overrides incompatible implementation inherited from RNNModel."""
         raise NotImplementedError(
-            f"Beam search not supported for {self.name} model"
+            f"Beam search is not supported by {self.name} model"
         )
 
     def decode(

--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -100,7 +100,7 @@ class HardAttentionRNNModel(rnn.RNNModel):
     def beam_decode(self, *args, **kwargs):
         """Overrides incompatible implementation inherited from RNNModel."""
         raise NotImplementedError(
-            f"Beam search not implemented for {self.name} model"
+            f"Beam search not supported for {self.name} model"
         )
 
     def decode(

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -211,7 +211,7 @@ class PointerGeneratorRNNModel(rnn.RNNModel, PointerGeneratorModel):
     def beam_decode(self, *args, **kwargs):
         """Overrides incompatible implementation inherited from RNNModel."""
         raise NotImplementedError(
-            f"Beam search not supported for {self.name} model"
+            f"Beam search is not supported by {self.name} model"
         )
 
     @abc.abstractmethod

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -211,7 +211,7 @@ class PointerGeneratorRNNModel(rnn.RNNModel, PointerGeneratorModel):
     def beam_decode(self, *args, **kwargs):
         """Overrides incompatible implementation inherited from RNNModel."""
         raise NotImplementedError(
-            f"Beam search not implemented for {self.name} model"
+            f"Beam search not supported for {self.name} model"
         )
 
     @abc.abstractmethod

--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -184,7 +184,7 @@ class RNNModel(base.BaseModel):
         if self.has_features_encoder:
             raise NotImplementedError(
                 "Separate features encoders are not supported "
-                f"for {self.name} model"
+                f"by {self.name} model"
             )
         encoder_out = self.source_encoder(batch.source).output
         # This function has a polymorphic return because beam search needs to

--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -59,7 +59,7 @@ class RNNModel(base.BaseModel):
         batch_size = encoder_mask.size(0)
         if batch_size != 1:
             raise NotImplementedError(
-                "Beam search is not implemented for batch_size > 1"
+                "Beam search is not supported for batch_size > 1"
             )
         # Initializes hidden states for decoder LSTM.
         decoder_hiddens = self.init_hiddens(batch_size)
@@ -177,6 +177,11 @@ class RNNModel(base.BaseModel):
                 a tensor of predictions of shape
                 B x seq_len x target_vocab_size.
         """
+        # TODO(#313): add support for this.
+        if self.has_features_encoder:
+            raise NotImplementedError(
+                "Separate features encoder not supported for {self.name} model"
+            )
         encoder_out = self.source_encoder(batch.source).output
         # This function has a polymorphic return because beam search needs to
         # return two tensors. For greedy, the return has not been modified to

--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -176,11 +176,15 @@ class RNNModel(base.BaseModel):
                 log-probabilities) for each prediction; greedy search returns
                 a tensor of predictions of shape
                 B x seq_len x target_vocab_size.
+
+        Raises:
+            NotImplementedError: separate features encoders are not supported.
         """
         # TODO(#313): add support for this.
         if self.has_features_encoder:
             raise NotImplementedError(
-                "Separate features encoder not supported for {self.name} model"
+                "Separate features encoders are not supported "
+                f"for {self.name} model"
             )
         encoder_out = self.source_encoder(batch.source).output
         # This function has a polymorphic return because beam search needs to

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -62,7 +62,7 @@ class TransducerRNNModel(rnn.RNNModel):
     def beam_decode(self, *args, **kwargs):
         """Overrides incompatible implementation inherited from RNNModel."""
         raise NotImplementedError(
-            f"Beam search not implemented for {self.name} model"
+            f"Beam search not supported for {self.name} model"
         )
 
     @property

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -62,7 +62,7 @@ class TransducerRNNModel(rnn.RNNModel):
     def beam_decode(self, *args, **kwargs):
         """Overrides incompatible implementation inherited from RNNModel."""
         raise NotImplementedError(
-            f"Beam search is not supported for {self.name} model"
+            f"Beam search is not supported by {self.name} model"
         )
 
     @property

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -62,7 +62,7 @@ class TransducerRNNModel(rnn.RNNModel):
     def beam_decode(self, *args, **kwargs):
         """Overrides incompatible implementation inherited from RNNModel."""
         raise NotImplementedError(
-            f"Beam search not supported for {self.name} model"
+            f"Beam search is not supported for {self.name} model"
         )
 
     @property

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -57,7 +57,7 @@ class TransformerModel(base.BaseModel):
 
     def beam_decode(self, *args, **kwargs):
         raise NotImplementedError(
-            f"Beam search not supported for {self.name} model"
+            f"Beam search is not supported for {self.name} model"
         )
 
     def forward(
@@ -71,11 +71,15 @@ class TransformerModel(base.BaseModel):
 
         Returns:
             torch.Tensor.
+
+        Raises:
+            NotImplementedError: separate features encoders are not supported.
         """
         # TODO(#313): add support for this.
         if self.has_features_encoder:
             raise NotImplementedError(
-                "Separate features encoder not supported for {self.name} model"
+                "Separate features encoders are not supported for "
+                "{self.name} model"
             )
         if self.training and self.teacher_forcing:
             assert (

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -21,8 +21,7 @@ class TransformerModel(base.BaseModel):
     """
 
     # Model arguments.
-    source_attention_heads: int
-    # Constructed inside __init__.
+    source_attention_heads: int  # Constructed inside __init__.
     classifier: nn.Linear
 
     def __init__(
@@ -57,13 +56,10 @@ class TransformerModel(base.BaseModel):
 
     def beam_decode(self, *args, **kwargs):
         raise NotImplementedError(
-            f"Beam search is not supported for {self.name} model"
+            f"Beam search is not supported by {self.name} model"
         )
 
-    def forward(
-        self,
-        batch: data.PaddedBatch,
-    ) -> torch.Tensor:
+    def forward(self, batch: data.PaddedBatch) -> torch.Tensor:
         """Runs the encoder-decoder.
 
         Args:
@@ -78,7 +74,7 @@ class TransformerModel(base.BaseModel):
         # TODO(#313): add support for this.
         if self.has_features_encoder:
             raise NotImplementedError(
-                "Separate features encoders are not supported for "
+                "Separate features encoders are not supported by "
                 "{self.name} model"
             )
         if self.training and self.teacher_forcing:

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -57,7 +57,7 @@ class TransformerModel(base.BaseModel):
 
     def beam_decode(self, *args, **kwargs):
         raise NotImplementedError(
-            f"Beam search not implemented for {self.name} model"
+            f"Beam search not supported for {self.name} model"
         )
 
     def forward(
@@ -72,6 +72,11 @@ class TransformerModel(base.BaseModel):
         Returns:
             torch.Tensor.
         """
+        # TODO(#313): add support for this.
+        if self.has_features_encoder:
+            raise NotImplementedError(
+                "Separate features encoder not supported for {self.name} model"
+            )
         if self.training and self.teacher_forcing:
             assert (
                 batch.has_target


### PR DESCRIPTION
Transformers and RNNs do not yet support separate features encoders. Making them do so is probably straightforward, but in the meantime we make them raise an error. (This happens during the `forward` phase, which is late, but this is a temporary measure.)

Addresses but does not close #313.