### PR TITLE
Supports separate encoders with vanilla RNNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ present, the `--features_encoder_arch` flag. Valid values are:
     the transformer encoder used with features; it concatenates source and
     features and uses a learned embedding to distinguish between source and
     features symbols.
--   `linear`: a linear encoder.
+-   `embedding`: a non-contextual embedding encoder.
 -   `gru`: a GRU encoder.
 -   `lstm`: a LSTM encoder.
 -   `transformer`: a transformer encoder.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = ["examples*"]
 
 [project]
 name = "yoyodyne"
-version = "0.3.1"
+version = "0.3.2"
 description = "Small-vocabulary neural sequence-to-sequence models"
 readme = "README.md"
 requires-python = ">= 3.10"

--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -180,6 +180,7 @@ class HardAttentionRNNModel(rnn.RNNModel):
             transitions = self._apply_mono_mask(transitions)
         return scores, transitions, state
 
+    # FIXME remove me
     @property
     def decoder_input_size(self) -> int:
         if self.has_features_encoder:
@@ -321,8 +322,9 @@ class HardAttentionRNNModel(rnn.RNNModel):
         encoded = self.source_encoder(batch.source)
         if self.has_features_encoder:
             features_encoded = self.features_encoder(batch.features)
-            # Averages to flatten, then expands across the interior dimension
-            # to match encoder output.
+            # Feature information is averaged across all positions, broadcast
+            # across the length of the source, and then concatenated with the
+            # source encoding along the encoding dimension.
             features_encoded = features_encoded.mean(dim=1, keepdim=True)
             features_encoded = features_encoded.expand(-1, encoded.size(1), -1)
             encoded = torch.cat((encoded, features_encoded), dim=2)

--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -180,17 +180,6 @@ class HardAttentionRNNModel(rnn.RNNModel):
             transitions = self._apply_mono_mask(transitions)
         return scores, transitions, state
 
-    # FIXME remove me
-    @property
-    def decoder_input_size(self) -> int:
-        if self.has_features_encoder:
-            return (
-                self.source_encoder.output_size
-                + self.features_encoder.output_size
-            )
-        else:
-            return self.source_encoder.output_size
-
     def greedy_decode(
         self,
         source_encoded: torch.Tensor,

--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -321,11 +321,10 @@ class HardAttentionRNNModel(rnn.RNNModel):
         encoded = self.source_encoder(batch.source)
         if self.has_features_encoder:
             features_encoded = self.features_encoder(batch.features)
-            # Averages to flatten embedding; this is done as an alternative to
-            # the linear projection used in the original paper.
+            # Averages to flatten, then expands across the interior dimension
+            # to match encoder output.
             features_encoded = features_encoded.mean(dim=1, keepdim=True)
             features_encoded = features_encoded.expand(-1, encoded.size(1), -1)
-            # Concatenates with the encoded source.
             encoded = torch.cat((encoded, features_encoded), dim=2)
         if self.training:
             return self.decode(

--- a/yoyodyne/models/modules/__init__.py
+++ b/yoyodyne/models/modules/__init__.py
@@ -10,7 +10,7 @@ from .hard_attention import ContextHardAttentionLSTMDecoder  # noqa: F401
 from .hard_attention import HardAttentionRNNDecoder  # noqa: F401
 from .hard_attention import HardAttentionGRUDecoder  # noqa: F401
 from .hard_attention import HardAttentionLSTMDecoder  # noqa: F401
-from .linear import LinearEncoder
+from .embedding import EmbeddingEncoder
 from .rnn import AttentiveGRUDecoder  # noqa: F401
 from .rnn import AttentiveLSTMDecoder  # noqa: F401
 from .rnn import GRUDecoder  # noqa: F401
@@ -36,7 +36,7 @@ class EncoderMismatchError(Error):
 _encoder_fac = {
     "feature_invariant_transformer": FeatureInvariantTransformerEncoder,
     "gru": GRUEncoder,
-    "linear": LinearEncoder,
+    "embedding": EmbeddingEncoder,
     "lstm": LSTMEncoder,
     "transformer": TransformerEncoder,
 }
@@ -108,7 +108,7 @@ def add_argparse_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--features_encoder_arch",
-        choices=["gru", "linear", "lstm", "transformer"],
+        choices=["embedding", "gru", "lstm", "transformer"],
         help="Model architecture to use for the features encoder.",
     )
 

--- a/yoyodyne/models/modules/embedding.py
+++ b/yoyodyne/models/modules/embedding.py
@@ -1,4 +1,4 @@
-"""Linear module class."""
+"""Embedding module class."""
 
 from ... import data
 from . import base
@@ -6,7 +6,12 @@ from . import base
 import torch
 
 
-class LinearEncoder(base.BaseModule):
+class EmbeddingEncoder(base.BaseModule):
+    """Embeds the input tensor.
+
+    This encoder produces non-contextual encoding of the input tensor simply
+    by embedding it. No other work is done.
+    """
 
     def forward(self, source: data.PaddedTensor) -> torch.Tensor:
         """Encodes the input.
@@ -21,7 +26,7 @@ class LinearEncoder(base.BaseModule):
 
     @property
     def name(self) -> str:
-        return "linear"
+        return "embedding"
 
     @property
     def output_size(self) -> int:

--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -111,7 +111,7 @@ class RNNModel(base.BaseModel):
                 + self.features_encoder.output_size
             )
         else:
-            return self.source_encoder.out
+            return self.source_encoder.output_size
 
     def forward(
         self,

--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -33,8 +33,8 @@ class RNNModel(base.BaseModel):
 
     def beam_decode(
         self,
-        source_encoded: torch.Tensor,
-        source_mask: torch.Tensor,
+        encoded: torch.Tensor,
+        mask: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Decodes with beam search.
 
@@ -46,8 +46,8 @@ class RNNModel(base.BaseModel):
         are still assumed to have a leading dimension representing batch size.
 
         Args:
-            source_encoded (torch.Tensor): encoded source symbols.
-            source_mask (torch.Tensor): mask for the source.
+            encoded (torch.Tensor).
+            mask (torch.Tensor).
 
         Returns:
             Tuple[torch.Tensor, torch.Tensor]: predictions of shape
@@ -55,7 +55,7 @@ class RNNModel(base.BaseModel):
                 B x beam_width.
         """
         # TODO: modify to work with batches larger than 1.
-        batch_size = source_mask.size(0)
+        batch_size = mask.size(0)
         if batch_size != 1:
             raise NotImplementedError(
                 "Beam search is not supported for batch_size > 1"
@@ -71,10 +71,7 @@ class RNNModel(base.BaseModel):
                 else:
                     symbol = torch.tensor([[cell.symbol]], device=self.device)
                     logits, state = self.decode_step(
-                        source_encoded,
-                        source_mask,
-                        symbol,
-                        cell.state,
+                        encoded, mask, symbol, cell.state
                     )
                     scores = nn.functional.log_softmax(logits.squeeze(), dim=0)
                     for new_cell in cell.extensions(state, scores):
@@ -86,25 +83,23 @@ class RNNModel(base.BaseModel):
 
     def decode_step(
         self,
-        source_encoded: torch.Tensor,
-        source_mask: torch.Tensor,
+        encoded: torch.Tensor,
+        mask: torch.Tensor,
         symbol: torch.Tensor,
         state: modules.RNNState,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Single step of the decoder.
 
         Args:
-            source_encoded (torch.Tensor): encoded source symbols.
-            source_mask (torch.Tensor): mask for hte source.
+            encoded (torch.Tensor).
+            mask (torch.Tensor).
             symbol (torch.Tensor): next symbol.
             state (modules.RNNState): RNN state.
 
         Returns:
             Tuple[torch.Tensor, modules.RNNState]: logits and the RNN state.
         """
-        decoded, state = self.decoder(
-            source_encoded, source_mask, symbol, state
-        )
+        decoded, state = self.decoder(encoded, mask, symbol, state)
         logits = self.classifier(decoded)
         return logits, state
 
@@ -116,7 +111,7 @@ class RNNModel(base.BaseModel):
                 + self.features_encoder.output_size
             )
         else:
-            return self.source_encoder.output_size
+            return self.source_encoder.out
 
     def forward(
         self,
@@ -142,8 +137,9 @@ class RNNModel(base.BaseModel):
         encoded = self.source_encoder(batch.source)
         if self.has_features_encoder:
             features_encoded = self.features_encoder(batch.features)
-            # Averages to flatten, then expands across the interior dimension
-            # to match encoder output.
+            # Feature information is averaged across all positions, broadcast
+            # across the length of the source, and then concatenated with the
+            # source encoding along the encoding dimension.
             features_encoded = features_encoded.mean(dim=1, keepdim=True)
             features_encoded = features_encoded.expand(-1, encoded.size(1), -1)
             encoded = torch.cat((encoded, features_encoded), dim=2)
@@ -162,8 +158,8 @@ class RNNModel(base.BaseModel):
 
     def greedy_decode(
         self,
-        source_encoded: torch.Tensor,
-        source_mask: torch.Tensor,
+        encoded: torch.Tensor,
+        mask: torch.Tensor,
         teacher_forcing: bool = defaults.TEACHER_FORCING,
         target: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
@@ -176,8 +172,8 @@ class RNNModel(base.BaseModel):
         sequences have reached END.
 
         Args:
-            source_encoded (torch.Tensor): encoded source symbols.
-            source_mask (torch.Tensor): mask.
+            encoded (torch.Tensor).
+            mask (torch.Tensor).
             teacher_forcing (bool, optional): whether or not to decode with
                 teacher forcing.
             target (torch.Tensor, optional): target symbols; if provided
@@ -186,7 +182,7 @@ class RNNModel(base.BaseModel):
         Returns:
             torch.Tensor: predictions of B x target_vocab_size x seq_len.
         """
-        batch_size = source_mask.size(0)
+        batch_size = mask.size(0)
         symbol = self.start_symbol(batch_size)
         state = self.decoder.initial_state(batch_size)
         predictions = []
@@ -197,9 +193,7 @@ class RNNModel(base.BaseModel):
         else:
             max_num_steps = target.size(1)
         for t in range(max_num_steps):
-            logits, state = self.decode_step(
-                source_encoded, source_mask, symbol, state
-            )
+            logits, state = self.decode_step(encoded, mask, symbol, state)
             predictions.append(logits.squeeze(1))
             # With teacher forcing the next input is the gold symbol for this
             # step; with student forcing, it's the top prediction.


### PR DESCRIPTION
This PR adds support for separate encoders in vanilla RNNs; it addresses #313 (but doesn't touch transformers so it does not close it). We adopt the merging approach from the hard attention models, which works with both "linear" and RNN features encoders. Suppose that the source encoder generates $B \times L \times E$ and the features encoder generates $B \times L' \times E'$. To create the final encoding, we first average features encodings across all positions producing a tensor of size $B \times 1 \times E'$. We then expand this tensor to $B \times L \times E'$ by broadcasting it across all positions in the source tensor. We then concatenate along the encoding dimension, producing a new tensor of size $B \times L \times (E + E')$.  The effect can be likened to spreading the features encoder information across all positions and thus roughly doubling the size of the encoding. 

# Fixes

* The `LinearEncoder` layer is misnamed because it's just a non-contextual embedding, with no actual affine projections. It is renamed `EmbeddingEncoder` and documentation is adjusted to match. 
* A separate `attention_input_size` argument is no longer necessary because it is always the same as `decoder_input_size`.
* The `NotImplementedError` is removed because it is in fact implemented.

# Alternatives considered

I experimented with concatenating along the length dimension instead. This works when there are two RNNs of the same hidden size and dimensionality but would break if the features encoder is just an embedding because E and E' may not match (indeed, one common rule of thumb is to use a hidden layer size 4x of the embedding size). We _could_ also add an affine $E' \times E$ projection linear layer to the embedding encoder, but that'd only be applicable for vanilla RNNs and wouldn't make sense elsewhere. If one wants a length concatenation effect, one can probably just use a single source/features encoder and the default concatenation, and the proposal in #301 provides an even more principled generalization of that idea. So I reject this idea.

# Future work

Complete #313 by adding something appropriate for transformers.