### PR TITLE
Replaces best_hyperparameters

### DIFF
--- a/examples/wandb_sweeps/README.md
+++ b/examples/wandb_sweeps/README.md
@@ -43,8 +43,6 @@ Then, one can retrieve the results as follows:
 3.  Click on the downward arrow link, select "CSV Export", then click "Save as
     CSV".
 
-Alternatively, one can use [`best_hyperparameters.py`](best_hyperparamaters.py)
-to retrieve the hyperparameters of the best run, formatted as CLI flags:
+Or, to get the hyperparameters from a particular run, copy the "Run path" from the run's "Overview" on W&B, and then run:
 
-    ./best_hyperparameters.py --entity "${ENTITY}" --project "${PROJECT}" \
-         --sweep_id "${SWEEP_ID}"
+    ./get_hyperparameters.py "${RUN_PATH}"

--- a/examples/wandb_sweeps/get_hyperparameters.py
+++ b/examples/wandb_sweeps/get_hyperparameters.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Retrieve hyperparameters from a W&B sweep."""
+"""Retrieves hyperparameters from a W&B run."""
 
 import argparse
 import logging
@@ -8,20 +8,20 @@ import wandb
 
 from yoyodyne import defaults
 
+from yoyodyne import defaults
+
 # Expand as needed.
 FLAGS_TO_IGNORE = frozenset(
-    ["eval_metrics", "local_run_dir", "n_model_params"]
+    ["eval_metrics", "local_run_dir", "num_parameters"]
 )
 
 
 def main(args: argparse.Namespace) -> None:
     api = wandb.Api()
-    sweep = api.sweep(f"{args.entity}/{args.project}/{args.sweep_id}")
-    best_run = sweep.best_run()
-    logging.info("Best run URL: %s", best_run.url)
-    # Sorting for stability.
+    run = api.run(f"{args.run_path}")
+    logging.info("Run URL: %s", run.url)
     args = []
-    for key, value in sorted(best_run.config.items()):
+    for key, value in sorted(run.config.items()):
         # Exclusions:
         #
         # * Explicitly ignored flags
@@ -54,12 +54,6 @@ if __name__ == "__main__":
     logging.basicConfig(format="%(levelname)s: %(message)s", level="INFO")
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--entity",
-        required=True,
-        help="The entity scope for the project.",
+        "run_path", help="Run path (in the form entity/project/run_id)"
     )
-    parser.add_argument(
-        "--project", required=True, help="The project of the sweep."
-    )
-    parser.add_argument("--sweep_id", required=True, help="ID for the sweep.")
     main(parser.parse_args())

--- a/examples/wandb_sweeps/get_hyperparameters.py
+++ b/examples/wandb_sweeps/get_hyperparameters.py
@@ -8,8 +8,6 @@ import wandb
 
 from yoyodyne import defaults
 
-from yoyodyne import defaults
-
 # Expand as needed.
 FLAGS_TO_IGNORE = frozenset(
     ["eval_metrics", "local_run_dir", "num_parameters"]


### PR DESCRIPTION
The best_hyperparameters.py script is limited because it doesn't understand max/min logic. That is, it **cannot** report which run achieved the highest validation accuracy, only which had the highest final validation accuracy. However, you can retrieve this information from the W&B website.

Therefore we modify this script to take a run as argument and return its hyperparameters. Sample use:

```
./get_hyperparameters.py cuny-cl/SIGMORPHON-2020-pointer_generator_rnn-kor_rom/qhl0rqhv
```

This returns the hyperparameters for that run, which I previously determined to be the best using W&B's run spreadsheet.