### PR TITLE
Fixes auto-config of loggers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yoyodyne"
-version = "0.4.1"
+version = "0.4.2"
 description = "Small-vocabulary neural sequence-to-sequence models"
 license = { text = "Apache 2.0" }
 readme = "README.md"

--- a/tests/testdata/configs/real_trainer.yaml
+++ b/tests/testdata/configs/real_trainer.yaml
@@ -1,7 +1,6 @@
 precision: bf16-mixed
 gradient_clip_val: 3
 max_epochs: 50
-max_time: 00:00:10:00
 callbacks:
   - class_path: lightning.pytorch.callbacks.LearningRateMonitor
     init_args:
@@ -11,3 +10,5 @@ callbacks:
       monitor: val_loss
       patience: 10
       verbose: true
+logger:
+  - class_path: lightning.pytorch.loggers.CSVLogger

--- a/tests/testdata/configs/toy_trainer.yaml
+++ b/tests/testdata/configs/toy_trainer.yaml
@@ -1,8 +1,9 @@
 precision: bf16-mixed
 gradient_clip_val: 3
 max_epochs: 20
-max_time: 00:00:02:00
 callbacks:
   - class_path: lightning.pytorch.callbacks.LearningRateMonitor
     init_args:
       logging_interval: epoch
+logger:
+  - class_path: lightning.pytorch.loggers.CSVLogger

--- a/yoyodyne/cli/main.py
+++ b/yoyodyne/cli/main.py
@@ -58,15 +58,11 @@ def main() -> None:
     YoyodyneCLI(
         model_class=models.BaseModel,
         datamodule_class=data.DataModule,
+        save_config_callback=None,
         subclass_mode_model=True,
         # Prevents predictions from accumulating in memory; see the
         # documentation in `trainers.py` for more context.
         trainer_class=trainers.Trainer,
-        # Makes sure there's always at least one logger. Without this,
-        # no checkpoints are stored.
-        trainer_defaults={
-            "logger": {"class_path": "lightning.pytorch.loggers.CSVLogger"}
-        },
     )
 
 
@@ -75,11 +71,9 @@ def python_interface(args: cli.ArgsType = None) -> None:
     YoyodyneCLI(
         models.BaseModel,
         data.DataModule,
+        save_config_callback=None,
         subclass_mode_model=True,
         # See above for explanation.
         trainer_class=trainers.Trainer,
-        trainer_defaults={
-            "logger": {"class_path": "lightning.pytorch.loggers.CSVLogger"}
-        },
         args=args,
     )

--- a/yoyodyne/cli/sweep.py
+++ b/yoyodyne/cli/sweep.py
@@ -65,6 +65,10 @@ def populate_config(
 
 
 def main() -> None:
+    logging.basicConfig(
+        format="%(filename)s %(levelname)s: %(asctime)s - %(message)s",
+        level="INFO",
+    )
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--sweep_id", required=True, help="ID for the sweep.")
     parser.add_argument(


### PR DESCRIPTION
In a previous revision I attempted to set things up so a CSV logger was always automatically configured. This does not play nice with W&B sweeps though: for reasons I don't fully understand, it would:

* rename every run in a sweep to "lightning_logs" after initialization
* attempt and fail to write `config.yaml` to the same location, causing a failure on later runs.

Some minor drive-bys are done on sample config files as well and logging is enabled for the sweep engine. 