### PR TITLE
Unused padding feature

### DIFF
--- a/yoyodyne/data/batches.py
+++ b/yoyodyne/data/batches.py
@@ -102,11 +102,11 @@ class Batch(nn.Module):
         self.register_module("target", target)
 
     @property
-    def has_features(self):
+    def has_features(self) -> bool:
         return self.features is not None
 
     @property
-    def has_target(self):
+    def has_target(self) -> bool:
         return self.target is not None
 
     def __len__(self) -> int:


### PR DESCRIPTION
This PR removes an unused padding size feature.

The `PaddedTensor` object allows one to decide whether padding ought to be determined automatically, or permits the user to specify a max padding size. The latter feature is never used in the library---we always use the automatic sizing---so I simply  remove it, getting rid of an if/else deep in the library.

I also do a driveby on some documentation and typing.