### PR TITLE
Passes `target_sep` to prediction callback

### DIFF
--- a/yoyodyne/callbacks.py
+++ b/yoyodyne/callbacks.py
@@ -19,7 +19,6 @@ class PredictionWriter(callbacks.BasePredictionWriter):
     """
 
     path: str
-    target_sep: str
     sink: Optional[TextIO]
 
     # path is given a default argument to silence a warning if no prediction
@@ -34,8 +33,8 @@ class PredictionWriter(callbacks.BasePredictionWriter):
     ):
         super().__init__("batch")
         self.path = path
-        self.target_sep = target_sep
         self.sink = None
+        self.target_sep = target_sep
 
     # Required API.
 

--- a/yoyodyne/cli/main.py
+++ b/yoyodyne/cli/main.py
@@ -38,6 +38,11 @@ class YoyodyneCLI(cli.LightningCLI):
             apply_on="instantiate",
         )
         parser.link_arguments(
+            "data.target_sep",
+            "prediction.target_sep",
+            apply_on="instantiate",
+        )
+        parser.link_arguments(
             "data.vocab_size",
             "model.init_args.vocab_size",
             apply_on="instantiate",

--- a/yoyodyne/data/datamodules.py
+++ b/yoyodyne/data/datamodules.py
@@ -182,6 +182,10 @@ class DataModule(lightning.LightningDataModule):
         return self.parser.has_target
 
     @property
+    def target_sep(self) -> str:
+        return self.parser.target_sep
+
+    @property
     def target_vocab_size(self) -> int:
         return self.index.target_vocab_size
 


### PR DESCRIPTION
Previously this was ignored. It actually can be solved with a simple link, it seems.