### PR TITLE
Adds an informative error

### DIFF
--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -10,6 +10,10 @@ from .. import data, defaults, special
 from . import base, embeddings, modules
 
 
+class Error(Exception):
+    pass
+
+
 class HardAttentionRNNModel(base.BaseModel):
     """Abstract base class for hard attention models.
 
@@ -303,6 +307,10 @@ class HardAttentionRNNModel(base.BaseModel):
         """
         encoded = self.source_encoder(batch.source, self.embeddings)
         if self.has_features_encoder:
+            if not batch.features:
+                raise Error(
+                    "Features encoder enabled, but no feature column specified"
+                )
             features_encoded = self.features_encoder(
                 batch.features, self.embeddings
             )

--- a/yoyodyne/models/pointer_generator.py
+++ b/yoyodyne/models/pointer_generator.py
@@ -274,6 +274,10 @@ class PointerGeneratorRNNModel(PointerGeneratorModel, rnn.RNNModel):
         """
         source_encoded = self.source_encoder(batch.source, self.embeddings)
         if self.has_features_encoder:
+            if not batch.features:
+                raise Error(
+                    "Features encoder enabled, but no feature column specified"
+                )
             features_encoded = self.features_encoder(
                 batch.features, self.embeddings
             )
@@ -571,6 +575,10 @@ class PointerGeneratorTransformerModel(
         """
         source_encoded = self.source_encoder(batch.source, self.embeddings)
         if self.has_features_encoder:
+            if not batch.features:
+                raise Error(
+                    "Features encoder enabled, but no feature column specified"
+                )
             features_encoded = self.features_encoder(
                 batch.features, self.embeddings
             )

--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -170,6 +170,10 @@ class RNNModel(base.BaseModel):
         encoded = self.source_encoder(batch.source, self.embeddings)
         mask = batch.source.mask
         if self.has_features_encoder:
+            if not batch.features:
+                raise Error(
+                    "Features encoder enabled, but no feature column specified"
+                )
             sequence = torch.cat((sequence, batch.features.padded), dim=1)
             features_encoded = self.features_encoder(
                 batch.features, self.embeddings

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -12,6 +12,10 @@ from .. import data, defaults, special, util
 from . import base, embeddings, expert, modules
 
 
+class Error(Exception):
+    pass
+
+
 class TransducerRNNModel(base.BaseModel):
     """Abstract base class for transducer models.
 
@@ -106,6 +110,10 @@ class TransducerRNNModel(base.BaseModel):
         source = batch.source.padded[:, 1:]
         source_mask = batch.source.mask[:, 1:]
         if self.has_features_encoder:
+            if not batch.features:
+                raise Error(
+                    "Features encoder enabled, but no feature column specified"
+                )
             features_encoded = self.features_encoder(
                 batch.features, self.embeddings
             )

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -99,15 +99,18 @@ class TransformerModel(base.BaseModel):
         encoded = self.source_encoder(batch.source, self.embeddings)
         mask = batch.source.mask
         if self.has_features_encoder:
+            if not batch.features:
+                raise Error(
+                    "Features encoder enabled, but no feature column specified"
+                )
             features_encoded = self.features_encoder(
                 batch.features, self.embeddings
             )
             encoded = torch.cat((encoded, features_encoded), dim=1)
             mask = torch.cat((mask, batch.features.mask), dim=1)
         if self.training and self.teacher_forcing:
-            assert (
-                batch.has_target
-            ), "Teacher forcing requested but no target provided"
+            if not batch.has_target:
+                raise Error("Teacher forcing requested but no target provided")
             batch_size = len(batch)
             symbol = self.start_symbol(batch_size)
             target = torch.cat((symbol, batch.target.padded), dim=1)


### PR DESCRIPTION
This now fires when a features encoder is specified but features are not.

E.g.: `yoyodyne.models.hard_attention.Error: Features encoder enabled, but no feature column specified`

I took the liberty of adding this separately to our five major classes since the alternative, definining a `forward` method in the base class and having all of the superclass call it like `super().forward(...)` struck me as no more future-proof. (A new model designer could easily forget to make this superclass call, or want/need a different signature for `forward`.)

Reported by @Othergreengrasses, where the error was also inscrutable to me until I put a bunch of debugging in. Seems like there's a need.