### PR TITLE
Adds `self.validating` property

### DIFF
--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -200,6 +200,13 @@ class BaseModel(abc.ABC, lightning.LightningModule):
     def has_ser(self) -> bool:
         return self.ser is not None
 
+    @property
+    def validating(self) -> bool:
+        # Parallel to the built-in self.training.
+        return self.trainer and (
+            self.trainer.validating or self.trainer.sanity_checking
+        )
+
     def start_symbol(self, batch_size: int) -> torch.Tensor:
         """Generates a tensor of start symbols for the batch."""
         return torch.tensor([special.START_IDX], device=self.device).repeat(

--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -227,9 +227,7 @@ class HardAttentionRNNModel(base.BaseModel):
             batch.source.mask,
             batch.target.padded if batch.has_target else None,
         )
-        if self.trainer and (
-            self.trainer.validating or self.trainer.sanity_checking
-        ):
+        if self.validating:
             loss = self._loss(encoded, batch.source.mask, batch.target.padded)
             return loss, predictions
         else:


### PR DESCRIPTION
This is parallel to the built-in self.training, but doesn't exist in the system, but it's easy to cobble together. Hard attention uses this to determine whether or not to compute loss.

The sanity checking stage runs `validation_step`, so we treat that as a case of validation.