### PR TITLE
Enables unit testing on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ workflows:
             python -m build && \
             twine check dist/`ls dist/ | grep .tar.gz` && \
             twine check dist/`ls dist/ | grep .whl`
-      - build-python:
+      - build-test-python:
           requires:
             - black
             - flake8


### PR DESCRIPTION
Before this we were just testing style and buildability. The long integration tests still need to be run locally, of course. 