### PR TITLE
Migrates to Python (>=)3.9 typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yoyodyne"
-version = "0.5.12"
+version = "0.5.13"
 description = "Small-vocabulary neural sequence-to-sequence models"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/yoyodyne_test.py
+++ b/tests/yoyodyne_test.py
@@ -8,7 +8,6 @@ import difflib
 import os
 import re
 import tempfile
-from typing import Dict, Optional, Tuple
 
 import pytest
 
@@ -89,8 +88,8 @@ INFLECTION_ARCH = [
 SEED = 49
 
 # Session-scoped state for checkpoint caching. Keyed by (data, arch).
-_checkpoints: Dict[Tuple[str, str], str] = {}
-_session_tempdir: Optional[tempfile.TemporaryDirectory] = None
+_checkpoints: dict[tuple[str, str], str] = {}
+_session_tempdir: tempfile.TemporaryDirectory | None = None
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/yoyodyne/callbacks.py
+++ b/yoyodyne/callbacks.py
@@ -2,7 +2,7 @@
 
 import csv
 import itertools
-from typing import Optional, Sequence, TextIO, Tuple, Union
+from typing import Sequence, TextIO
 
 import lightning
 import torch
@@ -19,7 +19,7 @@ class PredictionWriter(callbacks.BasePredictionWriter):
     """
 
     path: str
-    sink: Optional[TextIO]
+    sink: TextIO | None
 
     # path is given a default argument to silence a warning if no prediction
     # callback is configured.
@@ -51,7 +51,7 @@ class PredictionWriter(callbacks.BasePredictionWriter):
         self,
         trainer: trainer.Trainer,
         model: models.BaseModel,
-        predictions: Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor],
+        predictions: tuple[torch.Tensor, torch.Tensor] | torch.Tensor,
         batch_indices: Sequence[int] | None,
         batch: data.Batch,
         batch_idx: int,

--- a/yoyodyne/cli/hyperparameters.py
+++ b/yoyodyne/cli/hyperparameters.py
@@ -2,7 +2,7 @@
 
 import argparse
 import logging
-from typing import Any, Dict
+from typing import Any
 
 import wandb
 import yaml
@@ -15,7 +15,7 @@ ALLOWED_TOP_LEVEL_CATEGORIES = frozenset(
 )
 
 
-def dot_to_nested_dict(flat_dict: Dict[str, Any]) -> Dict[str, Any]:
+def dot_to_nested_dict(flat_dict: dict[str, Any]) -> dict[str, Any]:
     """Converts dot notation dictionary to nested dictionary.
 
     Args:

--- a/yoyodyne/cli/sweep.py
+++ b/yoyodyne/cli/sweep.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 import traceback
 import warnings
-from typing import Any, Dict, List
+from typing import Any
 
 import wandb
 import yaml
@@ -19,8 +19,8 @@ warnings.filterwarnings("ignore", ".*is a wandb run already in progress.*")
 
 
 def train_sweep(
-    config: Dict[str, Any],
-    argv_template: List[str],
+    config: dict[str, Any],
+    argv_template: list[str],
 ) -> None:
     """Runs a single training run.
 
@@ -43,7 +43,7 @@ def train_sweep(
 
 
 def populate_config(
-    config: Dict[str, Any],
+    config: dict[str, Any],
     temp_config_handle,
 ) -> None:
     """Populates temporary configuration file.
@@ -61,7 +61,7 @@ def populate_config(
     temp_config_handle.flush()
 
 
-def run_sweep(argv: List[str]) -> None:
+def run_sweep(argv: list[str]) -> None:
     """Actually runs the sweep.
 
     Args:

--- a/yoyodyne/data/batches.py
+++ b/yoyodyne/data/batches.py
@@ -6,8 +6,6 @@ Trainer to move them to the appropriate device."""
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 import torch
 from torch import nn
 
@@ -31,7 +29,7 @@ class PaddedTensor(nn.Module):
 
     def __init__(
         self,
-        tensorlist: List[torch.Tensor],
+        tensorlist: list[torch.Tensor],
     ):
         super().__init__()
         pad_len = max(len(tensor) for tensor in tensorlist)
@@ -97,8 +95,8 @@ class Batch(nn.Module):
     """
 
     source: PaddedTensor
-    features: Optional[PaddedTensor]
-    target: Optional[PaddedTensor]
+    features: PaddedTensor | None
+    target: PaddedTensor | None
 
     def __init__(self, source, features=None, target=None):
         super().__init__()

--- a/yoyodyne/data/collators.py
+++ b/yoyodyne/data/collators.py
@@ -1,7 +1,6 @@
 """Collators and related utilities."""
 
 import dataclasses
-from typing import List
 
 from . import batches, datasets
 
@@ -18,7 +17,7 @@ class Collator:
     has_target: bool
 
     def pad_source(
-        self, itemlist: List[datasets.Item]
+        self, itemlist: list[datasets.Item]
     ) -> batches.PaddedTensor:
         """Pads source.
 
@@ -34,7 +33,7 @@ class Collator:
 
     def pad_features(
         self,
-        itemlist: List[datasets.Item],
+        itemlist: list[datasets.Item],
     ) -> batches.PaddedTensor:
         """Pads features.
 
@@ -49,7 +48,7 @@ class Collator:
         )
 
     def pad_target(
-        self, itemlist: List[datasets.Item]
+        self, itemlist: list[datasets.Item]
     ) -> batches.PaddedTensor:
         """Pads target.
 
@@ -63,7 +62,7 @@ class Collator:
             [item.target for item in itemlist],
         )
 
-    def __call__(self, itemlist: List[datasets.Item]) -> batches.Batch:
+    def __call__(self, itemlist: list[datasets.Item]) -> batches.Batch:
         """Pads all elements of an itemlist.
 
         Args:

--- a/yoyodyne/data/datamodules.py
+++ b/yoyodyne/data/datamodules.py
@@ -1,7 +1,7 @@
 """Data modules."""
 
 import logging
-from typing import Iterable, Optional, Set
+from typing import Iterable
 
 import lightning
 from torch.utils import data
@@ -48,10 +48,10 @@ class DataModule(lightning.LightningDataModule):
             exceeds this limit.
     """
 
-    train: Optional[str]
-    val: Optional[str]
-    predict: Optional[str]
-    test: Optional[str]
+    train: str | None
+    val: str | None
+    predict: str | None
+    test: str | None
     parser: tsv.TsvParser
     batch_size: int
     index: indexes.Index
@@ -62,10 +62,10 @@ class DataModule(lightning.LightningDataModule):
         # Paths.
         *,
         model_dir: str,
-        train: Optional[str] = None,
-        val: Optional[str] = None,
-        predict: Optional[str] = None,
-        test: Optional[str] = None,
+        train: str | None = None,
+        val: str | None = None,
+        predict: str | None = None,
+        test: str | None = None,
         # TSV parsing arguments.
         source_col: int = defaults.SOURCE_COL,
         features_col: int = defaults.FEATURES_COL,
@@ -115,9 +115,9 @@ class DataModule(lightning.LightningDataModule):
 
     def _make_index(self, tie_embeddings: bool) -> indexes.Index:
         """Creates the index from a training set."""
-        source_vocabulary: Set[str] = set()
-        features_vocabulary: Set[str] = set()
-        target_vocabulary: Set[str] = set()
+        source_vocabulary: set[str] = set()
+        features_vocabulary: set[str] = set()
+        target_vocabulary: set[str] = set()
         if self.has_features:
             if self.has_target:
                 for source, features, target in self.parser.samples(

--- a/yoyodyne/data/datasets.py
+++ b/yoyodyne/data/datasets.py
@@ -3,7 +3,7 @@
 import abc
 import dataclasses
 import mmap
-from typing import BinaryIO, Iterator, List, Optional
+from typing import BinaryIO, Iterator
 
 import torch
 from torch import nn
@@ -25,8 +25,8 @@ class Item(nn.Module):
     """
 
     source: torch.Tensor
-    features: Optional[torch.Tensor]
-    target: Optional[torch.Tensor]
+    features: torch.Tensor | None
+    target: torch.Tensor | None
 
     def __init__(self, source, features=None, target=None):
         super().__init__()
@@ -107,9 +107,9 @@ class MappableDataset(AbstractDataset, data.Dataset):
 
     sequential: bool = False
 
-    _offsets: List[int] = dataclasses.field(default_factory=list, init=False)
-    _mmap: Optional[mmap.mmap] = dataclasses.field(default=None, init=False)
-    _fobj: Optional[BinaryIO] = dataclasses.field(default=None, init=False)
+    _offsets: list[int] = dataclasses.field(default_factory=list, init=False)
+    _mmap: mmap.mmap | None = dataclasses.field(default=None, init=False)
+    _fobj: BinaryIO | None = dataclasses.field(default=None, init=False)
 
     def __post_init__(self):
         self._offsets = []

--- a/yoyodyne/data/indexes.py
+++ b/yoyodyne/data/indexes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import itertools
 import pickle
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Iterable
 
 import yaml
 from torch import serialization
@@ -26,19 +26,19 @@ class Index:
         tie_embeddings (bool).
     """
 
-    source_vocabulary: List[str]
-    features_vocabulary: Optional[List[str]]
-    target_vocabulary: List[str]
+    source_vocabulary: list[str]
+    features_vocabulary: list[str] | None
+    target_vocabulary: list[str]
     tie_embeddings: bool
-    _index2symbol: List[str]
-    _symbol2index: Dict[str, int]
+    _index2symbol: list[str]
+    _symbol2index: dict[str, int]
 
     def __init__(
         self,
         *,
         source_vocabulary: Iterable[str],
-        features_vocabulary: Optional[Iterable[str]] = None,
-        target_vocabulary: Optional[Iterable[str]] = None,
+        features_vocabulary: Iterable[str] | None = None,
+        target_vocabulary: Iterable[str] | None = None,
         tie_embeddings: bool = defaults.TIE_EMBEDDINGS,
     ):
         super().__init__()
@@ -156,7 +156,7 @@ class Index:
             tie_embeddings=node_value.get("tie_embeddings"),
         )
 
-    def __reduce__(self) -> Tuple[Any, Tuple[Dict[str, Any]]]:
+    def __reduce__(self) -> tuple[Any, tuple[dict[str, Any]]]:
         return (
             _reconstruct_index,
             (
@@ -172,7 +172,7 @@ class Index:
     # Properties.
 
     @property
-    def symbols(self) -> List[str]:
+    def symbols(self) -> list[str]:
         return list(self._symbol2index.keys())
 
     @property
@@ -203,7 +203,7 @@ class Index:
 # This whitelists the Index for safe serialization.
 
 
-def _reconstruct_index(state: Dict[str, Any]) -> Index:
+def _reconstruct_index(state: dict[str, Any]) -> Index:
     return Index(**state)
 
 

--- a/yoyodyne/data/mappers.py
+++ b/yoyodyne/data/mappers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Iterable, List
+from typing import Iterable
 
 import torch
 
@@ -85,7 +85,7 @@ class Mapper:
     def _decode(
         self,
         indices: torch.Tensor,
-    ) -> List[str]:
+    ) -> list[str]:
         """Decodes a tensor.
 
         Decoding halts at END; other special symbols are omitted.
@@ -109,17 +109,17 @@ class Mapper:
     def decode_source(
         self,
         indices: torch.Tensor,
-    ) -> List[str]:
+    ) -> list[str]:
         return self._decode(indices)
 
     def decode_features(
         self,
         indices: torch.Tensor,
-    ) -> List[str]:
+    ) -> list[str]:
         return self._decode(indices)
 
     def decode_target(
         self,
         indices: torch.Tensor,
-    ) -> List[str]:
+    ) -> list[str]:
         return self._decode(indices)

--- a/yoyodyne/data/tsv.py
+++ b/yoyodyne/data/tsv.py
@@ -5,7 +5,7 @@ separators."""
 
 import csv
 import dataclasses
-from typing import Iterator, List, Tuple, Union
+from typing import Iterator
 
 from .. import defaults
 
@@ -14,11 +14,11 @@ class Error(Exception):
     pass
 
 
-SampleType = Union[
-    List[str],
-    Tuple[List[str], List[str]],
-    Tuple[List[str], List[str], List[str]],
-]
+SampleType = (
+    list[str]
+    | tuple[list[str], list[str]]
+    | tuple[list[str], list[str], list[str]]
+)
 
 
 @dataclasses.dataclass
@@ -78,7 +78,7 @@ class TsvParser:
             for row in csv.reader(source, delimiter="\t"):
                 yield self._row_to_sample(row)
 
-    def _row_to_sample(self, row: List[str]) -> SampleType:
+    def _row_to_sample(self, row: list[str]) -> SampleType:
         """Internal helper to convert a split row into a SampleType."""
         source = self.source_symbols(self._get_string(row, self.source_col))  #
         if self.has_features:
@@ -99,7 +99,7 @@ class TsvParser:
         return source
 
     @staticmethod
-    def _get_string(row: List[str], col: int) -> str:
+    def _get_string(row: list[str], col: int) -> str:
         """Returns a string from a row by index.
 
         Args:
@@ -121,36 +121,36 @@ class TsvParser:
     # String parsing methods.
 
     @staticmethod
-    def _get_symbols(string: str, sep: str) -> List[str]:
+    def _get_symbols(string: str, sep: str) -> list[str]:
         return list(string) if not sep else string.split(sep)
 
-    def source_symbols(self, string: str) -> List[str]:
+    def source_symbols(self, string: str) -> list[str]:
         symbols = self._get_symbols(string, self.source_sep)
         # If not tied, then we distinguish the source vocab with {...}.
         if not self.tie_embeddings:
             return [f"{{{symbol}}}" for symbol in symbols]
         return symbols
 
-    def features_symbols(self, string: str) -> List[str]:
+    def features_symbols(self, string: str) -> list[str]:
         # We deliberately obfuscate these to avoid overlap with source.
         return [
             f"[{symbol}]"
             for symbol in self._get_symbols(string, self.features_sep)
         ]
 
-    def target_symbols(self, string: str) -> List[str]:
+    def target_symbols(self, string: str) -> list[str]:
         return self._get_symbols(string, self.target_sep)
 
     # Deserialization methods.
 
-    def source_string(self, symbols: List[str]) -> str:
+    def source_string(self, symbols: list[str]) -> str:
         return self.source_sep.join(symbols)
 
-    def features_string(self, symbols: List[str]) -> str:
+    def features_string(self, symbols: list[str]) -> str:
         return self.features_sep.join(
             # This indexing strips off the obfuscation.
             [symbol[1:-1] for symbol in symbols],
         )
 
-    def target_string(self, symbols: List[str]) -> str:
+    def target_string(self, symbols: list[str]) -> str:
         return self.target_sep.join(symbols)

--- a/yoyodyne/models/base.py
+++ b/yoyodyne/models/base.py
@@ -2,7 +2,7 @@
 
 import abc
 import logging
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable
 
 import lightning
 import torch
@@ -85,8 +85,8 @@ class BaseModel(abc.ABC, lightning.LightningModule):
     max_features_length: int
     max_target_length: int
 
-    source_encoder: Optional[modules.BaseEncoder]
-    features_encoder: Optional[modules.BaseEncoder]
+    source_encoder: modules.BaseEncoder | None
+    features_encoder: modules.BaseEncoder | None
     decoder: modules.BaseModule
     embedding: nn.Embedding
 
@@ -94,9 +94,9 @@ class BaseModel(abc.ABC, lightning.LightningModule):
     scheduler: optim.lr_scheduler.LRScheduler
 
     beam_width: int
-    accuracy: Optional[metrics.Accuracy]
-    ser: Optional[metrics.SER]
-    loss_func: Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]]
+    accuracy: metrics.Accuracy | None
+    ser: metrics.SER | None
+    loss_func: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None
 
     def __init__(
         self,
@@ -108,14 +108,14 @@ class BaseModel(abc.ABC, lightning.LightningModule):
         decoder_layers: int = defaults.LAYERS,
         decoder_dropout: float = defaults.DROPOUT,
         embedding_size: int = defaults.EMBEDDING_SIZE,
-        features_encoder: Union[modules.BaseEncoder, bool] = False,
+        features_encoder: modules.BaseEncoder | bool = False,
         label_smoothing: float = defaults.LABEL_SMOOTHING,
         max_source_length: int = defaults.MAX_LENGTH,
         max_features_length: int = defaults.MAX_LENGTH,
         max_target_length: int = defaults.MAX_LENGTH,
         optimizer: cli.OptimizerCallable = defaults.OPTIMIZER,
         scheduler: cli.LRSchedulerCallable = defaults.SCHEDULER,
-        source_encoder: Optional[modules.BaseEncoder] = None,
+        source_encoder: modules.BaseEncoder | None = None,
         target_vocab_size: int = -1,  # Dummy value filled in via link.
         vocab_size: int = -1,  # Dummy value filled in via link.
         **kwargs,  # Ignored here.
@@ -182,7 +182,7 @@ class BaseModel(abc.ABC, lightning.LightningModule):
 
     def _get_loss_func(
         self,
-    ) -> Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]]:
+    ) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None:
         """Returns the actual function used to compute loss.
 
         This is overridden by certain classes which compute loss as a side
@@ -254,7 +254,7 @@ class BaseModel(abc.ABC, lightning.LightningModule):
 
     def _align(
         self, predictions: torch.Tensor, target: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Pads predictions and target tensors along sequence dimension.
 
         This is useful for methods (e.g., student forcing training, or
@@ -306,7 +306,7 @@ class BaseModel(abc.ABC, lightning.LightningModule):
         self,
         batch: data.Batch,
         batch_idx: int,
-    ) -> Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor] | torch.Tensor:
         """Runs one predict step.
 
         If beam_width > 1 this invokes the forward method directly and returns

--- a/yoyodyne/models/beam_search.py
+++ b/yoyodyne/models/beam_search.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import dataclasses
 import heapq
-from typing import Iterator, List, Optional
+from typing import Iterator
 
 import torch
 from torch import nn
@@ -50,18 +50,18 @@ class Cell:
             decoders like transformers.
     """
 
-    symbols: List[int] = dataclasses.field(
+    symbols: list[int] = dataclasses.field(
         compare=False, default_factory=lambda: [special.START_IDX]
     )
     score: float = dataclasses.field(compare=True, default=0.0)
-    state: Optional[modules.RNNState] = dataclasses.field(
+    state: modules.RNNState | None = dataclasses.field(
         compare=False, default=None
     )
 
     def extensions(
         self,
         scores: torch.Tensor,
-        state: Optional[modules.RNNState] = None,
+        state: modules.RNNState | None = None,
     ) -> Iterator[Cell]:
         """Generates extension cells.
 
@@ -93,7 +93,7 @@ class Heap:
         heap (List[Cell], optional).
     """
 
-    heap: List[Cell]
+    heap: list[Cell]
 
     def __init__(self):
         self.heap = []
@@ -130,11 +130,11 @@ class Beam:
 
     beam_width: int
     # Current cells.
-    cells: List[Cell]
+    cells: list[Cell]
     # Heap of the next set of cells.
     heap: Heap
 
-    def __init__(self, beam_width, state: Optional[modules.RNNState] = None):
+    def __init__(self, beam_width, state: modules.RNNState | None = None):
         self.beam_width = beam_width
         self.cells = [Cell(state=state)]
         self.heap = Heap()

--- a/yoyodyne/models/expert.py
+++ b/yoyodyne/models/expert.py
@@ -8,7 +8,7 @@ dictionary. This class stores valid edit actions for given dataset."""
 
 import dataclasses
 import math
-from typing import Any, Dict, Iterable, List, Sequence, Set
+from typing import Any, Iterable, Sequence
 
 import numpy
 from maxwell import actions, sed
@@ -33,16 +33,16 @@ class ActionVocabulary:
     """Manages encoding of action vocabulary for transducer training."""
 
     # TODO: Port more of the logic to the dataset class.
-    i2w: List[actions.Edit]
-    w2i: Dict[actions.Edit, int]
+    i2w: list[actions.Edit]
+    w2i: dict[actions.Edit, int]
     beg_idx: int
     end_idx: int
     del_idx: int
     copy_idx: int
     start_vocab_idx: int
-    target_characters: Set[Any]
-    insertions: List[int]
-    substitutions: List[int]
+    target_characters: set[Any]
+    insertions: list[int]
+    substitutions: list[int]
 
     def __init__(self, index: data.indexes.Index):
         self.target_characters = set()
@@ -169,7 +169,7 @@ class Prefix:
 class ActionPrefix:
     """Class for wrapping possible actions associated with given prefix."""
 
-    action: Set[actions.Edit]
+    action: set[actions.Edit]
     prefix: Prefix
 
 
@@ -252,7 +252,7 @@ class Expert:
         source: Sequence[Any],
         alignment: int,
         prefixes: Iterable[Prefix],
-    ) -> List[ActionPrefix]:
+    ) -> list[ActionPrefix]:
         """Provides edit actions for source symbol and prefix.
 
         Args:
@@ -321,7 +321,7 @@ class Expert:
         target: Sequence[Any],
         alignment: int,
         action_prefixes: Iterable[ActionPrefix],
-    ) -> Dict[actions.Edit, float]:
+    ) -> dict[actions.Edit, float]:
         """Scores potential actions by a predicted 'cost to go' for target.
 
         Score sums potential edit sequence with cost of action.
@@ -370,7 +370,7 @@ class Expert:
         alignment: int,
         prediction: Sequence[Any],
         max_action_seq_len: int = 150,
-    ) -> Dict[actions.Edit, float]:
+    ) -> dict[actions.Edit, float]:
         """Provides potential actions given source, target, and prediction.
 
         Args:
@@ -398,7 +398,7 @@ class Expert:
     @staticmethod
     def find_prefixes(
         prediction: Sequence[Any], target: Sequence[Any]
-    ) -> List[Prefix]:
+    ) -> list[Prefix]:
         """Creates prefix objects for prediction and target.
 
         Args:

--- a/yoyodyne/models/hard_attention.py
+++ b/yoyodyne/models/hard_attention.py
@@ -1,7 +1,6 @@
 """Hard monotonic neural HMM classes."""
 
 import abc
-from typing import Optional, Tuple
 
 import torch
 from torch import nn
@@ -122,7 +121,7 @@ class HardAttentionRNNModel(base.BaseModel):
         mask: torch.Tensor,
         symbol: torch.Tensor,
         state: modules.RNNState,
-    ) -> Tuple[torch.Tensor, torch.Tensor, modules.RNNState]:
+    ) -> tuple[torch.Tensor, torch.Tensor, modules.RNNState]:
         """Single decoder step.
 
         Args:
@@ -199,7 +198,7 @@ class HardAttentionRNNModel(base.BaseModel):
         """
         return embeddings.normal_embedding(num_embeddings, embedding_size)
 
-    def forward(self, batch: data.Batch) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, batch: data.Batch) -> tuple[torch.Tensor, torch.Tensor]:
         """Forward pass.
 
         Args:
@@ -254,7 +253,7 @@ class HardAttentionRNNModel(base.BaseModel):
         self,
         encoded: torch.Tensor,
         mask: torch.Tensor,
-        target_length: Optional[int] = None,
+        target_length: int | None = None,
     ) -> torch.Tensor:
         """Decodes a sequence given the encoded input.
 

--- a/yoyodyne/models/modules/attention.py
+++ b/yoyodyne/models/modules/attention.py
@@ -1,7 +1,5 @@
 """Basic attention module classes."""
 
-from typing import Tuple
-
 import torch
 from torch import nn
 
@@ -45,7 +43,7 @@ class Attention(nn.Module):
         encoded: torch.Tensor,
         hidden: torch.Tensor,
         mask: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Computes the attention distribution.
 
         This computes attention for the encoder outputs w.r.t. the previous

--- a/yoyodyne/models/modules/hard_attention.py
+++ b/yoyodyne/models/modules/hard_attention.py
@@ -4,8 +4,6 @@ Hard attention models use unadulterated RNN encoders, but extend RNN decoders.
 There are separate decoders for zeroth-order (HardAttentionRNNDecoder) and
 first-order (ContextHardAttentionRNNDecoder) decoders."""
 
-from typing import Tuple
-
 import torch
 from torch import nn
 
@@ -46,7 +44,7 @@ class HardAttentionRNNDecoder(rnn.RNNDecoder):
         symbol: torch.Tensor,
         state: rnn.RNNState,
         embeddings: nn.Embedding,
-    ) -> Tuple[torch.Tensor, torch.Tensor, rnn.RNNState]:
+    ) -> tuple[torch.Tensor, torch.Tensor, rnn.RNNState]:
         """Single decode pass.
 
         Args:

--- a/yoyodyne/models/modules/multihead_attention.py
+++ b/yoyodyne/models/modules/multihead_attention.py
@@ -1,7 +1,6 @@
 """Multihead attention module classes."""
 
 import math
-from typing import Optional, Tuple
 
 import torch
 from torch import nn
@@ -71,11 +70,11 @@ class RotaryMultiheadAttention(nn.Module):
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
-        key_padding_mask: Optional[torch.Tensor] = None,
+        key_padding_mask: torch.Tensor | None = None,
         need_weights: bool = False,
-        attn_mask: Optional[torch.Tensor] = None,
+        attn_mask: torch.Tensor | None = None,
         is_causal: bool = False,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Computes RoPE-augmented multi-head attention.
 
         Args:

--- a/yoyodyne/models/modules/rnn.py
+++ b/yoyodyne/models/modules/rnn.py
@@ -13,7 +13,6 @@ and WrappedLSTMDecoder are similar wrappers for decoder modules.
 from __future__ import annotations
 
 import abc
-from typing import Optional, Tuple
 
 import torch
 from torch import nn
@@ -60,7 +59,7 @@ class RNNState(nn.Module):
     """Represents the state of an RNN."""
 
     hidden: torch.Tensor
-    cell: Optional[torch.Tensor]  # LSTMs only.
+    cell: torch.Tensor | None  # LSTMs only.
 
     def __init__(self, hidden, cell=None):
         super().__init__()
@@ -211,7 +210,7 @@ class WrappedGRUDecoder(nn.GRU):
 
     def forward(
         self, symbol: torch.Tensor, state: RNNState
-    ) -> Tuple[torch.Tensor, RNNState]:
+    ) -> tuple[torch.Tensor, RNNState]:
         decoded, hidden = super().forward(symbol, state.hidden)
         return decoded, RNNState(hidden)
 
@@ -221,7 +220,7 @@ class WrappedLSTMDecoder(nn.LSTM):
 
     def forward(
         self, symbol: torch.Tensor, state: RNNState
-    ) -> Tuple[torch.Tensor, RNNState]:
+    ) -> tuple[torch.Tensor, RNNState]:
         assert state.cell is not None, "expected cell state"
         decoded, (hidden, cell) = super().forward(
             symbol, (state.hidden, state.cell)
@@ -261,7 +260,7 @@ class RNNDecoder(RNNModule):
         context: torch.Tensor,
         mask: torch.Tensor,
         state: RNNState,
-    ) -> Tuple[torch.Tensor, RNNState]:
+    ) -> tuple[torch.Tensor, RNNState]:
         """Single decode pass.
 
         Args:
@@ -392,7 +391,7 @@ class SoftAttentionRNNDecoder(RNNDecoder):
         context: torch.Tensor,
         mask: torch.Tensor,
         state: RNNState,
-    ) -> Tuple[torch.Tensor, RNNState]:
+    ) -> tuple[torch.Tensor, RNNState]:
         """Single decode pass.
 
         Args:

--- a/yoyodyne/models/modules/transformer.py
+++ b/yoyodyne/models/modules/transformer.py
@@ -3,7 +3,6 @@
 import abc
 import collections
 import math
-from typing import Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -30,8 +29,8 @@ class AttentionOutput(collections.UserList):
     def __call__(
         self,
         module: nn.Module,
-        module_in: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
-        module_out: Tuple[torch.Tensor, torch.Tensor],
+        module_in: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        module_out: tuple[torch.Tensor, torch.Tensor],
     ) -> None:
         """Stores the second return argument of `module`.
 
@@ -72,8 +71,8 @@ class TransformerModule(base.BaseModule):
     esq: float
     hidden_size: int
     layers: int
-    module: Union[nn.TransformerEncoder, nn.TransformerDecoder]
-    positional_encoding: Optional[position.BasePositionalEncoding]
+    module: nn.TransformerEncoder | nn.TransformerDecoder
+    positional_encoding: position.BasePositionalEncoding | None
 
     def __init__(
         self,
@@ -81,8 +80,8 @@ class TransformerModule(base.BaseModule):
         attention_heads: int = defaults.ATTENTION_HEADS,
         hidden_size: int = defaults.HIDDEN_SIZE,
         layers: int = defaults.LAYERS,
-        max_length: Optional[int] = None,
-        positional_encoding: Optional[position.BasePositionalEncoding] = None,
+        max_length: int | None = None,
+        positional_encoding: position.BasePositionalEncoding | None = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -404,7 +403,7 @@ class WrappedTransformerDecoder(nn.TransformerDecoder):
         source_encoded: torch.Tensor,
         source_mask: torch.Tensor,
         target: torch.Tensor,
-        target_mask: Optional[torch.Tensor],
+        target_mask: torch.Tensor | None,
         causal_mask: torch.Tensor,
     ) -> torch.Tensor:
         return super().forward(
@@ -447,9 +446,9 @@ class TransformerDecoder(TransformerModule):
         source_encoded: torch.Tensor,
         source_mask: torch.Tensor,
         target: torch.Tensor,
-        target_mask: Optional[torch.Tensor],
+        target_mask: torch.Tensor | None,
         embeddings: nn.Embedding,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Performs single pass of decoder module.
 
         Args:
@@ -587,12 +586,12 @@ class PointerGeneratorTransformerDecoder(TransformerDecoder):
         source_encoded: torch.Tensor,
         source_mask: torch.Tensor,
         target: torch.Tensor,
-        target_mask: Optional[torch.Tensor],
+        target_mask: torch.Tensor | None,
         embeddings: nn.Embedding,
         *,
-        features_encoded: Optional[torch.Tensor] = None,
-        features_mask: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        features_encoded: torch.Tensor | None = None,
+        features_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Performs single pass of decoder module.
 
         Args:
@@ -698,7 +697,7 @@ class SeparateFeaturesTransformerDecoder(nn.TransformerDecoder):
         source_encoded: torch.Tensor,
         source_mask: torch.Tensor,
         target: torch.Tensor,
-        target_mask: Optional[torch.Tensor],
+        target_mask: torch.Tensor | None,
         features_encoded: torch.Tensor,
         features_mask: torch.Tensor,
         causal_mask: torch.Tensor,

--- a/yoyodyne/models/modules/transformer_layers.py
+++ b/yoyodyne/models/modules/transformer_layers.py
@@ -1,7 +1,5 @@
 """Transformer layer classes."""
 
-from typing import Optional
-
 import torch
 from torch import nn
 
@@ -147,7 +145,7 @@ class SeparateFeaturesTransformerDecoderLayer(nn.TransformerDecoderLayer):
         source_encoded: torch.Tensor,
         source_mask: torch.Tensor,
         target: torch.Tensor,
-        target_mask: Optional[torch.Tensor],
+        target_mask: torch.Tensor | None,
         features_encoded: torch.Tensor,
         features_mask: torch.Tensor,
         causal_mask: torch.Tensor,

--- a/yoyodyne/models/pointer_generator/rnn.py
+++ b/yoyodyne/models/pointer_generator/rnn.py
@@ -1,7 +1,5 @@
 """Pointer-generator RNN model classes."""
 
-from typing import Optional, Tuple, Union
-
 import torch
 from torch import nn
 
@@ -92,8 +90,8 @@ class PointerGeneratorRNNModel(base.PointerGeneratorModel):
         source_encoded: torch.Tensor,
         source_mask: torch.Tensor,
         *,
-        features_encoded: Optional[torch.Tensor] = None,
-        features_mask: Optional[torch.Tensor] = None,
+        features_encoded: torch.Tensor | None = None,
+        features_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Decodes with beam search.
 
@@ -158,9 +156,9 @@ class PointerGeneratorRNNModel(base.PointerGeneratorModel):
         symbol: torch.Tensor,
         state: modules.RNNState,
         *,
-        features_encoded: Optional[torch.Tensor] = None,
-        features_mask: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        features_encoded: torch.Tensor | None = None,
+        features_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Single decoder step.
 
         This predicts a distribution for one symbol.
@@ -238,7 +236,7 @@ class PointerGeneratorRNNModel(base.PointerGeneratorModel):
     def forward(
         self,
         batch: data.Batch,
-    ) -> Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor] | torch.Tensor:
         """Forward pass.
 
         Args:
@@ -330,9 +328,9 @@ class PointerGeneratorRNNModel(base.PointerGeneratorModel):
         source_encoded: torch.Tensor,
         source_mask: torch.Tensor,
         *,
-        target: Optional[torch.Tensor] = None,
-        features_encoded: Optional[torch.Tensor] = None,
-        features_mask: Optional[torch.Tensor] = None,
+        target: torch.Tensor | None = None,
+        features_encoded: torch.Tensor | None = None,
+        features_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Decodes greedily during training and validation.
 
@@ -394,8 +392,8 @@ class PointerGeneratorRNNModel(base.PointerGeneratorModel):
         source_encoded: torch.Tensor,
         source_mask: torch.Tensor,
         *,
-        features_encoded: Optional[torch.Tensor] = None,
-        features_mask: Optional[torch.Tensor] = None,
+        features_encoded: torch.Tensor | None = None,
+        features_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Decodes greedily during prediction and testing.
 

--- a/yoyodyne/models/pointer_generator/transformer.py
+++ b/yoyodyne/models/pointer_generator/transformer.py
@@ -1,7 +1,5 @@
 """Pointer-generator transformer model classes."""
 
-from typing import Optional, Tuple
-
 import torch
 from torch import nn
 
@@ -36,9 +34,9 @@ class PointerGeneratorTransformerModel(base.PointerGeneratorModel):
         self,
         *args,
         attention_heads: int = defaults.ATTENTION_HEADS,
-        decoder_positional_encoding: Optional[
-            modules.BasePositionalEncoding
-        ] = None,
+        decoder_positional_encoding: (
+            modules.BasePositionalEncoding | None
+        ) = None,
         teacher_forcing: bool = defaults.TEACHER_FORCING,
         **kwargs,
     ):
@@ -84,9 +82,9 @@ class PointerGeneratorTransformerModel(base.PointerGeneratorModel):
         source_encoded: torch.Tensor,
         source_mask: torch.Tensor,
         *,
-        features_encoded: Optional[torch.Tensor] = None,
-        features_mask: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        features_encoded: torch.Tensor | None = None,
+        features_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Decodes with beam search.
 
         Decoding halts once all sequences in the beam have reached END. It is
@@ -155,8 +153,8 @@ class PointerGeneratorTransformerModel(base.PointerGeneratorModel):
         target: torch.Tensor,
         target_mask: torch.Tensor,
         *,
-        features_encoded: Optional[torch.Tensor] = None,
-        features_mask: Optional[torch.Tensor] = None,
+        features_encoded: torch.Tensor | None = None,
+        features_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Single decoder step.
 
@@ -374,8 +372,8 @@ class PointerGeneratorTransformerModel(base.PointerGeneratorModel):
         source_encoded: torch.Tensor,
         source_mask: torch.Tensor,
         *,
-        features_encoded: Optional[torch.Tensor] = None,
-        features_mask: Optional[torch.Tensor] = None,
+        features_encoded: torch.Tensor | None = None,
+        features_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Decodes greedily during prediction and testing.
 

--- a/yoyodyne/models/rnn.py
+++ b/yoyodyne/models/rnn.py
@@ -6,7 +6,6 @@ concrete decoder modules.
 """
 
 import abc
-from typing import Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -68,7 +67,7 @@ class RNNModel(base.BaseModel):
         self,
         context: torch.Tensor,
         mask: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Decodes with beam search.
 
         Decoding halts once all sequences in a batch have reached END. It is
@@ -122,7 +121,7 @@ class RNNModel(base.BaseModel):
         context: torch.Tensor,
         mask: torch.Tensor,
         state: modules.RNNState,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Single step of the decoder.
 
         Args:
@@ -148,7 +147,7 @@ class RNNModel(base.BaseModel):
     def forward(
         self,
         batch: data.Batch,
-    ) -> Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor] | torch.Tensor:
         """Forward pass.
 
         Args:
@@ -218,7 +217,7 @@ class RNNModel(base.BaseModel):
         self,
         context: torch.Tensor,
         mask: torch.Tensor,
-        target: Optional[torch.Tensor] = None,
+        target: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Decodes greedily during training and validation.
 

--- a/yoyodyne/models/transducer.py
+++ b/yoyodyne/models/transducer.py
@@ -1,7 +1,7 @@
 """Transducer model classes."""
 
 import abc
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable
 
 import torch
 from maxwell import actions, sed
@@ -51,7 +51,7 @@ class TransducerRNNModel(base.BaseModel):
         self,
         sed_path: str,
         *args,
-        index: Optional[data.Index] = None,  # Dummy value filled in via link.
+        index: data.Index | None = None,  # Dummy value filled in via link.
         oracle_factor: int = defaults.ORACLE_FACTOR,
         teacher_forcing: bool = defaults.TEACHER_FORCING,
         **kwargs,
@@ -90,7 +90,7 @@ class TransducerRNNModel(base.BaseModel):
 
     def _get_loss_func(
         self,
-    ) -> Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]]:
+    ) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None:
         # Prevents base model from constructing a loss function we don't need;
         # the transducer computes loss as it goes.
         return None
@@ -108,7 +108,7 @@ class TransducerRNNModel(base.BaseModel):
     def forward(
         self,
         batch: data.Batch,
-    ) -> Tuple[List[List[int]], torch.Tensor]:
+    ) -> tuple[list[list[int]], torch.Tensor]:
         """Forward pass.
 
         Args:
@@ -163,9 +163,9 @@ class TransducerRNNModel(base.BaseModel):
         source: torch.Tensor,
         encoded: torch.Tensor,
         source_mask: torch.Tensor,
-        target: Optional[torch.Tensor] = None,
-        target_mask: Optional[torch.Tensor] = None,
-    ) -> Tuple[List[List[int]], torch.Tensor]:
+        target: torch.Tensor | None = None,
+        target_mask: torch.Tensor | None = None,
+    ) -> tuple[list[list[int]], torch.Tensor]:
         """Decodes a sequence given the encoded input.
 
         Prediction is performed as a side effect of training, so we also
@@ -195,7 +195,7 @@ class TransducerRNNModel(base.BaseModel):
             (batch_size,), self.actions.beg_idx, device=self.device
         )
         loss = torch.zeros(batch_size, device=self.device)
-        prediction: List[List[int]] = [[] for _ in range(batch_size)]
+        prediction: list[list[int]] = [[] for _ in range(batch_size)]
         state = self.decoder.initial_state(batch_size)
         context = self.decoder.get_context(source, encoded)
         # Converting encodings for prediction.
@@ -270,12 +270,12 @@ class TransducerRNNModel(base.BaseModel):
 
     def _batch_expert_rollout(
         self,
-        source: List[List[int]],
-        target: List[List[int]],
+        source: list[list[int]],
+        target: list[list[int]],
         alignment: torch.Tensor,
-        prediction: List[List[int]],
+        prediction: list[list[int]],
         nonfinal: torch.Tensor,
-    ) -> List[List[int]]:
+    ) -> list[list[int]]:
         """Performs expert rollout over batch.
 
         Args:
@@ -305,11 +305,11 @@ class TransducerRNNModel(base.BaseModel):
 
     def _expert_rollout(
         self,
-        source: List[int],
-        target: List[int],
+        source: list[int],
+        target: list[int],
         alignment: int,
-        prediction: List[int],
-    ) -> List[int]:
+        prediction: list[int],
+    ) -> list[int]:
         """Rolls out with optimal expert policy.
 
         Args:
@@ -344,7 +344,7 @@ class TransducerRNNModel(base.BaseModel):
         alignment: torch.Tensor,
         lengths: torch.Tensor,
         nonfinal: torch.Tensor,
-        optim_actions: Optional[List[List[int]]] = None,
+        optim_actions: list[list[int]] | None = None,
     ) -> torch.Tensor:
         """Decodes logits to find edit action.
 
@@ -380,7 +380,7 @@ class TransducerRNNModel(base.BaseModel):
         logits = self._action_probability_mask(logits, valid_actions)
         return self._choose_action(logits, nonfinal_list, optim_actions)
 
-    def _compute_valid_actions(self, end_of_input: bool) -> List[int]:
+    def _compute_valid_actions(self, end_of_input: bool) -> list[int]:
         """Gives all possible actions for remaining length of edits.
 
         Args:
@@ -398,7 +398,7 @@ class TransducerRNNModel(base.BaseModel):
         return valid_actions
 
     def _action_probability_mask(
-        self, logits: torch.Tensor, valid_actions: List[List[int]]
+        self, logits: torch.Tensor, valid_actions: list[list[int]]
     ) -> torch.Tensor:
         """Masks non-valid actions in logits.
 
@@ -423,8 +423,8 @@ class TransducerRNNModel(base.BaseModel):
     def _choose_action(
         self,
         logits: torch.Tensor,
-        nonfinal: List[bool],
-        optim_actions: Optional[List[List[int]]] = None,
+        nonfinal: list[bool],
+        optim_actions: list[list[int]] | None = None,
     ) -> torch.Tensor:
         """Chooses transducer action from log-probability distribution.
 
@@ -480,8 +480,8 @@ class TransducerRNNModel(base.BaseModel):
     # TODO: Merge action classes in Maxwell to remove the need for this method.
     @staticmethod
     def _remap_actions(
-        action_scores: Dict[actions.Edit, float],
-    ) -> Dict[actions.Edit, float]:
+        action_scores: dict[actions.Edit, float],
+    ) -> dict[actions.Edit, float]:
         """Maps generative oracle edits to their conditional counterparts.
 
         The Maxwell expert emits generative edit actions while the transducer
@@ -496,7 +496,7 @@ class TransducerRNNModel(base.BaseModel):
             Dict[actions.Edit, float]: edit action-weight pairs using
                 conditional edit types.
         """
-        remapped: Dict[actions.Edit, float] = {}
+        remapped: dict[actions.Edit, float] = {}
         for action, score in action_scores.items():
             if isinstance(action, actions.GenerativeEdit):
                 remapped[action.conditional_counterpart()] = score
@@ -512,9 +512,9 @@ class TransducerRNNModel(base.BaseModel):
     def _update_prediction(
         self,
         action: torch.Tensor,
-        source: List[List[int]],
+        source: list[list[int]],
         alignment: torch.Tensor,
-        prediction: List[List[int]],
+        prediction: list[list[int]],
     ) -> torch.Tensor:
         """Batch updates prediction and alignment information from actions.
 
@@ -559,7 +559,7 @@ class TransducerRNNModel(base.BaseModel):
     @staticmethod
     def _log_sum_softmax_loss(
         logits: torch.Tensor,
-        optimal_actions: List[List[int]],
+        optimal_actions: list[list[int]],
     ) -> torch.Tensor:
         """Computes per-item negative marginal log-likelihood loss.
 
@@ -658,7 +658,7 @@ class TransducerRNNModel(base.BaseModel):
         )
 
     def _convert_predictions(
-        self, predictions: List[List[int]], length: int
+        self, predictions: list[list[int]], length: int
     ) -> torch.Tensor:
         """Converts a batch of predictions to the proper form.
 
@@ -682,7 +682,7 @@ class TransducerRNNModel(base.BaseModel):
         )
 
     def _resize_prediction(
-        self, prediction: List[int], length: int
+        self, prediction: list[int], length: int
     ) -> torch.Tensor:
         """Resizes the prediction and converts to tensor.
 

--- a/yoyodyne/models/transformer.py
+++ b/yoyodyne/models/transformer.py
@@ -1,7 +1,5 @@
 """Transformer model classes."""
 
-from typing import Optional, Tuple
-
 import torch
 from torch import nn
 
@@ -38,9 +36,9 @@ class TransformerModel(base.BaseModel):
         self,
         *args,
         attention_heads: int = defaults.ATTENTION_HEADS,
-        decoder_positional_encoding: Optional[
-            modules.BasePositionalEncoding
-        ] = None,
+        decoder_positional_encoding: (
+            modules.BasePositionalEncoding | None
+        ) = None,
         teacher_forcing: bool = defaults.TEACHER_FORCING,
         **kwargs,
     ):
@@ -80,7 +78,7 @@ class TransformerModel(base.BaseModel):
         self,
         encoded: torch.Tensor,
         mask: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Decodes with beam search.
 
         Decoding halts once all sequences in the beam have reached END. It is
@@ -365,7 +363,7 @@ class CausalTransformerModel(base.BaseModel):
         self,
         *args,
         attention_heads: int = defaults.ATTENTION_HEADS,
-        positional_encoding: Optional[modules.BasePositionalEncoding] = None,
+        positional_encoding: modules.BasePositionalEncoding | None = None,
         teacher_forcing: bool = defaults.TEACHER_FORCING,
         **kwargs,
     ):
@@ -406,7 +404,7 @@ class CausalTransformerModel(base.BaseModel):
     def beam_decode(
         self,
         prefix: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Decodes with beam search.
 
         Decoding halts once all sequences in the beam have reached END. It is

--- a/yoyodyne/schedulers.py
+++ b/yoyodyne/schedulers.py
@@ -1,7 +1,6 @@
 """Custom schedulers."""
 
 import math
-from typing import List
 
 from torch import optim
 
@@ -19,7 +18,7 @@ class Dummy(optim.lr_scheduler.LRScheduler):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.optimizer})"
 
-    def get_lr(self) -> List[float]:
+    def get_lr(self) -> list[float]:
         return [group["lr"] for group in self.optimizer.param_groups]
 
 

--- a/yoyodyne/sizing.py
+++ b/yoyodyne/sizing.py
@@ -2,7 +2,6 @@
 
 import logging
 import math
-from typing import Tuple
 
 import lightning
 from lightning.pytorch.tuner import tuning
@@ -16,7 +15,7 @@ class Error(Exception):
 
 def _optimal_batch_size(
     desired_batch_size: int, max_batch_size: int
-) -> Tuple[int, int]:
+) -> tuple[int, int]:
     r"""Computes optimal batch size and number of gradient accumulation steps.
 
     Given the desired batch size $b$ and a max batch size $n_{\textrm{max}}$,

--- a/yoyodyne/util.py
+++ b/yoyodyne/util.py
@@ -2,7 +2,7 @@
 
 import logging
 import os
-from typing import Any, Dict
+from typing import Any
 
 import torch
 import yaml
@@ -66,7 +66,7 @@ def pad_tensor_after_end(
     return predictions
 
 
-def load_config(path: str) -> Dict[str, Any]:
+def load_config(path: str) -> dict[str, Any]:
     """Loads a YAML config file, parsing the LINKS field separately.
 
     Args:
@@ -79,7 +79,7 @@ def load_config(path: str) -> Dict[str, Any]:
         return yaml.safe_load(source)
 
 
-def recursive_insert(config: Dict[str, Any], key: str, value) -> None:
+def recursive_insert(config: dict[str, Any], key: str, value) -> None:
     """Recursively inserts values into a nested dictionary.
 
     Args:


### PR DESCRIPTION
In this commit all concrete types previously imported from `typing` are now done with the build-in functions, and `|` is used for unions (including `Optional`, which is an implicit union with `None`). We still do need `typing` imports for abstract types like `Any`, `Callable`, etc. but far fewer ones are necessary.

Implementation:

* Run `ruff check --select UP006,UP007,UP045 --fix .`
* Using `flake8` remove unneeded imports from `typing`.