### PR TITLE
Inserts cleaner parameter summary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yoyodyne"
-version = "0.5.15"
+version = "0.5.16"
 description = "Small-vocabulary neural sequence-to-sequence models"
 license = "Apache-2.0"
 readme = "README.md"
@@ -37,7 +37,8 @@ dependencies = [
     "lightning==2.6.0",
     "maxwell>=0.2.6",
     "numpy>=2.0.0,<3.0.0",
-    "omegaconf==2.3.0",
+    "omegaconf>=2.3.0",
+    "rich>=15.0.0",
     "torch==2.9.1",
     # Not directly needed but can cause pinning problems.
     "torchaudio==2.9.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yoyodyne"
-version = "0.5.16"
+version = "0.5.15"
 description = "Small-vocabulary neural sequence-to-sequence models"
 license = "Apache-2.0"
 readme = "README.md"

--- a/yoyodyne/callbacks.py
+++ b/yoyodyne/callbacks.py
@@ -26,21 +26,23 @@ class CompactModelSummary(callbacks.ModelSummary):
         # Prevents redundant logging in multi-GPU setups.
         if not trainer.is_global_zero:
             return
-        summary = model_summary.ModelSummary(pl_module)
-        rows = [
-            (name, layer.layer_type, layer.num_parameters)
-            for name, layer in summary._layer_summary.items()
-            if layer.num_parameters > 0
-        ]
         param_table = table.Table(
             show_header=True, header_style="bold magenta"
         )
         param_table.add_column("Name")
         param_table.add_column("Type")
         param_table.add_column("Parameters", justify="right")
-        for name, type_, params in rows:
-            param_table.add_row(name, type_, f"{params:,}")
-        self._console.print(param_table)
+        summary = model_summary.ModelSummary(pl_module)
+        for name, layer in summary._layer_summary.items():
+            if layer.num_parameters == 0:
+                continue
+            param_table.add_row(
+                name, layer.layer_type, f"{layer.num_parameters:,}"
+            )
+        _console.print(param_table)
+        _console.print(
+            f"Trainable parameters: {summary.trainable_parameters:,}"
+        )
 
 
 class PredictionWriter(callbacks.BasePredictionWriter):

--- a/yoyodyne/callbacks.py
+++ b/yoyodyne/callbacks.py
@@ -7,8 +7,40 @@ from typing import Sequence, TextIO
 import lightning
 import torch
 from lightning.pytorch import callbacks, trainer
+from lightning.pytorch.utilities import model_summary
+from rich import console, table
 
 from . import data, defaults, models, util
+
+_console = console.Console()
+
+
+class CompactModelSummary(callbacks.ModelSummary):
+    """ModelSummary callback that hides zero-parameter rows."""
+
+    _console = console.Console()
+
+    def on_fit_start(
+        self, trainer: trainer.Trainer, pl_module: lightning.LightningModule
+    ) -> None:
+        # Prevents redundant logging in multi-GPU setups.
+        if not trainer.is_global_zero:
+            return
+        summary = model_summary.ModelSummary(pl_module)
+        rows = [
+            (name, layer.layer_type, layer.num_parameters)
+            for name, layer in summary._layer_summary.items()
+            if layer.num_parameters > 0
+        ]
+        param_table = table.Table(
+            show_header=True, header_style="bold magenta"
+        )
+        param_table.add_column("Name")
+        param_table.add_column("Type")
+        param_table.add_column("Parameters", justify="right")
+        for name, type_, params in rows:
+            param_table.add_row(name, type_, f"{params:,}")
+        self._console.print(param_table)
 
 
 class PredictionWriter(callbacks.BasePredictionWriter):

--- a/yoyodyne/cli/main.py
+++ b/yoyodyne/cli/main.py
@@ -81,28 +81,25 @@ def main() -> None:
         datefmt="%d-%b-%y %H:%M:%S",
         level="INFO",
     )
-    # Select the model.
-    YoyodyneCLI(
-        models.BaseModel,
-        data.DataModule,
-        parser_kwargs={"parser_mode": "omegaconf"},
-        save_config_callback=None,
-        subclass_mode_model=True,
-        # Prevents predictions from accumulating in memory; see the
-        # documentation in `trainers.py` for more context.
-        trainer_class=trainers.Trainer,
-    )
+    _run_cli()
 
 
-def python_interface(args: cli.ArgsType = None) -> None:
+def python_interface(args: cli.ArgsType | None = None) -> None:
     """Interface to use models through Python."""
+    return _run_cli(args)
+
+
+def _run_cli(args: cli.ArgsType | None = None) -> None:
     YoyodyneCLI(
         models.BaseModel,
         data.DataModule,
         parser_kwargs={"parser_mode": "omegaconf"},
         save_config_callback=None,
         subclass_mode_model=True,
-        # See above for explanation.
         trainer_class=trainers.Trainer,
+        trainer_defaults={
+            "callbacks": [callbacks.CompactModelSummary()],
+            "enable_model_summary": False,
+        },
         args=args,
     )

--- a/yoyodyne/models/modules/position.py
+++ b/yoyodyne/models/modules/position.py
@@ -3,7 +3,6 @@
 import abc
 import math
 
-import lightning
 import torch
 from torch import nn
 
@@ -14,7 +13,7 @@ class Error(Exception):
     pass
 
 
-class BasePositionalEncoding(abc.ABC, lightning.LightningModule):
+class BasePositionalEncoding(abc.ABC, nn.Module):
     """Abstract base class for positional encodings."""
 
     @abc.abstractmethod


### PR DESCRIPTION
This filters out zero-parameter modules, hides the useless "mode" argument, and the empty "FLOPs" argument, all with a callback.

As a driveby I correctly label positional modules as nn.Module, rather than as Lightning modules. I also DRY out the main CLI module a little. 