### PR TITLE
Separates out pointer-generator modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yoyodyne"
-version = "0.5.21"
+version = "0.5.22"
 description = "Small-vocabulary neural sequence-to-sequence models"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -35,6 +35,23 @@ class TestModel:
         )
         assert isinstance(model, models.CausalTransformerModel)
 
+    def test_feature_invariant_transformer(self):
+        model = models.TransformerModel(
+            source_encoder=modules.FeatureInvariantTransformerEncoder(),
+            features_encoder=True,
+            target_vocab_size=TARGET_VOCAB_SIZE,
+            vocab_size=VOCAB_SIZE,
+        )
+        assert isinstance(model, models.TransformerModel)
+
+    def test_gru(self):
+        model = models.GRUModel(
+            source_encoder=modules.GRUEncoder(),
+            target_vocab_size=TARGET_VOCAB_SIZE,
+            vocab_size=VOCAB_SIZE,
+        )
+        assert isinstance(model, models.GRUModel)
+
     def test_hard_attention_gru(self):
         model = models.HardAttentionGRUModel(
             source_encoder=modules.GRUEncoder(),
@@ -85,6 +102,66 @@ class TestModel:
             vocab_size=VOCAB_SIZE,
         )
         assert isinstance(model, models.HardAttentionLSTMModel)
+
+    def test_hard_attention_transformer(self):
+        model = models.HardAttentionTransformerModel(
+            source_encoder=modules.TransformerEncoder(),
+            target_vocab_size=TARGET_VOCAB_SIZE,
+            vocab_size=VOCAB_SIZE,
+        )
+        assert isinstance(model, models.HardAttentionTransformerModel)
+
+    def test_lstm(self):
+        model = models.LSTMModel(
+            source_encoder=modules.LSTMEncoder(),
+            target_vocab_size=TARGET_VOCAB_SIZE,
+            vocab_size=VOCAB_SIZE,
+        )
+        assert isinstance(model, models.LSTMModel)
+
+    def test_lstm_linear_features(self):
+        model = models.LSTMModel(
+            source_encoder=modules.LSTMEncoder(),
+            features_encoder=modules.LinearEncoder(),
+            target_vocab_size=TARGET_VOCAB_SIZE,
+            vocab_size=VOCAB_SIZE,
+        )
+        assert isinstance(model, models.LSTMModel)
+
+    def test_lstm_separate_features(self):
+        model = models.LSTMModel(
+            source_encoder=modules.LSTMEncoder(),
+            features_encoder=modules.LSTMEncoder(),
+            target_vocab_size=TARGET_VOCAB_SIZE,
+            vocab_size=VOCAB_SIZE,
+        )
+        assert isinstance(model, models.LSTMModel)
+
+    def test_lstm_shared_features(self):
+        model = models.LSTMModel(
+            source_encoder=modules.LSTMEncoder(),
+            features_encoder=True,
+            target_vocab_size=TARGET_VOCAB_SIZE,
+            vocab_size=VOCAB_SIZE,
+        )
+        assert isinstance(model, models.LSTMModel)
+
+    def test_lstm_transformer_features(self):
+        model = models.LSTMModel(
+            source_encoder=modules.LSTMEncoder(),
+            features_encoder=modules.TransformerEncoder(),
+            target_vocab_size=TARGET_VOCAB_SIZE,
+            vocab_size=VOCAB_SIZE,
+        )
+        assert isinstance(model, models.LSTMModel)
+
+    def test_lstm_transformer_source(self):
+        model = models.LSTMModel(
+            source_encoder=modules.TransformerEncoder(),
+            target_vocab_size=TARGET_VOCAB_SIZE,
+            vocab_size=VOCAB_SIZE,
+        )
+        assert isinstance(model, models.LSTMModel)
 
     def test_pointer_generator_gru(self):
         model = models.PointerGeneratorGRUModel(
@@ -143,66 +220,6 @@ class TestModel:
             vocab_size=VOCAB_SIZE,
         )
         assert isinstance(model, models.PointerGeneratorTransformerModel)
-
-    def test_gru(self):
-        model = models.GRUModel(
-            source_encoder=modules.GRUEncoder(),
-            target_vocab_size=TARGET_VOCAB_SIZE,
-            vocab_size=VOCAB_SIZE,
-        )
-        assert isinstance(model, models.GRUModel)
-
-    def test_lstm(self):
-        model = models.LSTMModel(
-            source_encoder=modules.LSTMEncoder(),
-            target_vocab_size=TARGET_VOCAB_SIZE,
-            vocab_size=VOCAB_SIZE,
-        )
-        assert isinstance(model, models.LSTMModel)
-
-    def test_lstm_linear_features(self):
-        model = models.LSTMModel(
-            source_encoder=modules.LSTMEncoder(),
-            features_encoder=modules.LinearEncoder(),
-            target_vocab_size=TARGET_VOCAB_SIZE,
-            vocab_size=VOCAB_SIZE,
-        )
-        assert isinstance(model, models.LSTMModel)
-
-    def test_lstm_separate_features(self):
-        model = models.LSTMModel(
-            source_encoder=modules.LSTMEncoder(),
-            features_encoder=modules.LSTMEncoder(),
-            target_vocab_size=TARGET_VOCAB_SIZE,
-            vocab_size=VOCAB_SIZE,
-        )
-        assert isinstance(model, models.LSTMModel)
-
-    def test_lstm_shared_features(self):
-        model = models.LSTMModel(
-            source_encoder=modules.LSTMEncoder(),
-            features_encoder=True,
-            target_vocab_size=TARGET_VOCAB_SIZE,
-            vocab_size=VOCAB_SIZE,
-        )
-        assert isinstance(model, models.LSTMModel)
-
-    def test_lstm_transformer_features(self):
-        model = models.LSTMModel(
-            source_encoder=modules.LSTMEncoder(),
-            features_encoder=modules.TransformerEncoder(),
-            target_vocab_size=TARGET_VOCAB_SIZE,
-            vocab_size=VOCAB_SIZE,
-        )
-        assert isinstance(model, models.LSTMModel)
-
-    def test_lstm_transformer_source(self):
-        model = models.LSTMModel(
-            source_encoder=modules.TransformerEncoder(),
-            target_vocab_size=TARGET_VOCAB_SIZE,
-            vocab_size=VOCAB_SIZE,
-        )
-        assert isinstance(model, models.LSTMModel)
 
     def test_soft_attention_gru(self):
         model = models.SoftAttentionGRUModel(
@@ -269,15 +286,6 @@ class TestModel:
         model = models.TransformerModel(
             source_encoder=modules.TransformerEncoder(),
             features_encoder=modules.TransformerEncoder(),
-            target_vocab_size=TARGET_VOCAB_SIZE,
-            vocab_size=VOCAB_SIZE,
-        )
-        assert isinstance(model, models.TransformerModel)
-
-    def test_feature_invariant_transformer(self):
-        model = models.TransformerModel(
-            source_encoder=modules.FeatureInvariantTransformerEncoder(),
-            features_encoder=True,
             target_vocab_size=TARGET_VOCAB_SIZE,
             vocab_size=VOCAB_SIZE,
         )

--- a/tests/module_test.py
+++ b/tests/module_test.py
@@ -17,32 +17,47 @@ class TestModule:
     @pytest.mark.parametrize(
         "mod",
         [
+            modules.CausalTransformerDecoder,
             modules.ContextHardAttentionGRUDecoder,
             modules.ContextHardAttentionLSTMDecoder,
+            modules.ContextHardAttentionTransformerDecoder,
+            modules.GRUDecoder,
+            modules.HardAttentionGRUDecoder,
+            modules.HardAttentionLSTMDecoder,
+            modules.HardAttentionTransformerDecoder,
+            modules.LSTMDecoder,
+            modules.PointerGeneratorTransformerDecoder,
+            modules.RotaryCausalTransformerDecoder,
+            modules.RotaryPointerGeneratorTransformerDecoder,
+            modules.RotaryTransformerDecoder,
+            modules.SoftAttentionGRUDecoder,
+            modules.SoftAttentionLSTMDecoder,
+            modules.TransformerDecoder,
         ],
     )
-    def test_context_hard_attention_rnn_decoders(self, mod):
+    def test_decoder(self, mod):
+        module = mod()
+        assert isinstance(module, mod)
+
+    @pytest.mark.parametrize(
+        "mod",
+        [
+            modules.FeatureInvariantTransformerEncoder,
+            modules.GRUEncoder,
+            modules.LinearEncoder,
+            modules.LSTMEncoder,
+            modules.RotaryFeatureInvariantTransformerEncoder,
+            modules.RotaryTransformerEncoder,
+            modules.TransformerEncoder,
+        ],
+    )
+    def test_encoder(self, mod):
         module = mod()
         assert isinstance(module, mod)
 
     def test_generation_probability(self):
         module = modules.GenerationProbability()
         assert isinstance(module, modules.GenerationProbability)
-
-    @pytest.mark.parametrize(
-        "mod",
-        [
-            modules.HardAttentionGRUDecoder,
-            modules.HardAttentionLSTMDecoder,
-        ],
-    )
-    def test_hard_attention_rnn_decoders(self, mod):
-        module = mod()
-        assert isinstance(module, mod)
-
-    def test_linear_encoder(self):
-        module = modules.LinearEncoder()
-        assert isinstance(module, modules.LinearEncoder)
 
     @pytest.mark.parametrize(
         "mod",
@@ -54,58 +69,5 @@ class TestModule:
         ],
     )
     def test_positional_encodings(self, mod):
-        module = mod()
-        assert isinstance(module, mod)
-
-    @pytest.mark.parametrize(
-        "mod",
-        [modules.GRUDecoder, modules.LSTMDecoder],
-    )
-    def test_rnn_decoders(self, mod):
-        module = mod()
-        assert isinstance(module, mod)
-
-    @pytest.mark.parametrize(
-        "mod",
-        [modules.GRUEncoder, modules.LSTMEncoder],
-    )
-    def test_rnn_encoders(self, mod):
-        module = mod()
-        assert isinstance(module, mod)
-
-    @pytest.mark.parametrize(
-        "mod",
-        [modules.SoftAttentionGRUDecoder, modules.SoftAttentionLSTMDecoder],
-    )
-    def test_soft_attention_rnn_decoders(self, mod):
-        module = mod()
-        assert isinstance(module, mod)
-
-    @pytest.mark.parametrize(
-        "mod",
-        [
-            modules.TransformerDecoder,
-            modules.CausalTransformerDecoder,
-            modules.PointerGeneratorTransformerDecoder,
-            modules.PointerGeneratorTransformerDecoder,
-            modules.RotaryCausalTransformerDecoder,
-            modules.RotaryPointerGeneratorTransformerDecoder,
-            modules.RotaryTransformerDecoder,
-        ],
-    )
-    def test_transformer_decoders(self, mod):
-        module = mod()
-        assert isinstance(module, mod)
-
-    @pytest.mark.parametrize(
-        "mod",
-        [
-            modules.TransformerEncoder,
-            modules.FeatureInvariantTransformerEncoder,
-            modules.RotaryFeatureInvariantTransformerEncoder,
-            modules.RotaryTransformerEncoder,
-        ],
-    )
-    def test_transformer_encoders(self, mod):
         module = mod()
         assert isinstance(module, mod)

--- a/yoyodyne/models/modules/__init__.py
+++ b/yoyodyne/models/modules/__init__.py
@@ -31,12 +31,14 @@ from .rnn import RNNDecoder  # noqa: F401
 from .rnn import RNNState  # noqa: F401
 from .rnn import SoftAttentionGRUDecoder  # noqa: F401
 from .rnn import SoftAttentionLSTMDecoder  # noqa: F401
+from .pointer_generator import PointerGeneratorTransformerDecoder  # noqa: F401
+from .pointer_generator import (  # noqa: F401
+    RotaryPointerGeneratorTransformerDecoder,
+)
 from .transformer import CausalTransformerDecoder  # noqa: F401
 from .transformer import FeatureInvariantTransformerEncoder  # noqa: F401
-from .transformer import PointerGeneratorTransformerDecoder  # noqa: F401
 from .transformer import RotaryCausalTransformerDecoder  # noqa: F401
 from .transformer import RotaryFeatureInvariantTransformerEncoder  # noqa: F401
-from .transformer import RotaryPointerGeneratorTransformerDecoder  # noqa: F401
 from .transformer import RotaryTransformerDecoder  # noqa: F401
 from .transformer import RotaryTransformerEncoder  # noqa: F401
 from .transformer import SeparateFeaturesTransformerDecoder  # noqa: F401

--- a/yoyodyne/models/modules/attention.py
+++ b/yoyodyne/models/modules/attention.py
@@ -6,10 +6,6 @@ from torch import nn
 from ... import defaults
 
 
-class Error(Exception):
-    pass
-
-
 class Attention(nn.Module):
     """Basic attention module.
 

--- a/yoyodyne/models/modules/hard_attention.py
+++ b/yoyodyne/models/modules/hard_attention.py
@@ -287,7 +287,8 @@ class HardAttentionTransformerDecoder(transformer.TransformerModule):
 
     Args:
         *args: passed to TransformerModule.
-        decoder_input_size (int): dimensionality of the source encoder output.
+        decoder_input_size (int, optional): dimensionality of the source
+            encoder output.
         **kwargs: passed to TransformerModule.
     """
 
@@ -296,7 +297,10 @@ class HardAttentionTransformerDecoder(transformer.TransformerModule):
     scale_encoded: nn.Linear
 
     def __init__(
-        self, *args, decoder_input_size: int = defaults.HIDDEN_SIZE, **kwargs
+        self,
+        *args,
+        decoder_input_size: int = defaults.EMBEDDING_SIZE,
+        **kwargs,
     ):
         # Must be set before super().__init__ so output_size is available
         # when output_proj and scale_encoded are built below.

--- a/yoyodyne/models/modules/hard_attention.py
+++ b/yoyodyne/models/modules/hard_attention.py
@@ -295,7 +295,9 @@ class HardAttentionTransformerDecoder(transformer.TransformerModule):
     output_proj: nn.Sequential
     scale_encoded: nn.Linear
 
-    def __init__(self, *args, decoder_input_size: int, **kwargs):
+    def __init__(
+        self, *args, decoder_input_size: int = defaults.HIDDEN_SIZE, **kwargs
+    ):
         # Must be set before super().__init__ so output_size is available
         # when output_proj and scale_encoded are built below.
         self.decoder_input_size = decoder_input_size

--- a/yoyodyne/models/modules/pointer_generator.py
+++ b/yoyodyne/models/modules/pointer_generator.py
@@ -1,0 +1,196 @@
+"""Pointer-generator module classes."""
+
+import torch
+from torch import nn
+
+from . import position, transformer, transformer_layers
+
+
+class PointerGeneratorTransformerDecoder(transformer.TransformerDecoder):
+    """A transformer decoder which tracks the output of multihead attention.
+
+    This is achieved with a hook into the forward pass.
+
+    After:
+        https://gist.github.com/airalcorn2/50ec06517ce96ecc143503e21fa6cb91
+
+    Args:
+        *args: passed to superclass.
+        has_features_encoder (bool, optional).
+        *kwargs: passed to superclass.
+    """
+
+    def __init__(
+        self,
+        *args,
+        has_features_encoder: bool = False,
+        **kwargs,
+    ):
+        self.has_features_encoder = has_features_encoder
+        super().__init__(*args, **kwargs)
+        # Stores the actual cross attentions.
+        self.attention_output = transformer.AttentionOutput()
+        # Refers to the attention from decoder to encoder.
+        self._patch_attention(self.module.layers[-1].multihead_attn)
+        self.hook_handle = self.module.layers[
+            -1
+        ].multihead_attn.register_forward_hook(self.attention_output)
+
+    def forward(
+        self,
+        source_encoded: torch.Tensor,
+        source_mask: torch.Tensor,
+        target: torch.Tensor,
+        target_mask: torch.Tensor | None,
+        embeddings: nn.Embedding,
+        *,
+        features_encoded: torch.Tensor | None = None,
+        features_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Performs single pass of decoder module.
+
+        Args:
+            source_encoded (torch.Tensor).
+            source_mask (torch.Tensor).
+            target (torch.Tensor): current targets, which may be the full
+                target or previous decoded, of shape B x seq_len x hidden_size.
+            target_mask (torch.Tensor).
+            embeddings (nn.Embedding).
+            features_encoded (torch.Tensor, optional).
+            features_mask (torch.Tensor, optional).
+
+        Returns:
+            tuple[torch.Tensor, torch.Tensor]: decoder outputs and the
+                embedded targets.
+        """
+        target_embedded = self.embed(target, embeddings)
+        causal_mask = self._causal_mask(target_embedded.size(1))
+        # -> B x seq_len x d_model.
+        if self.has_features_encoder:
+            decoded = self.module(
+                source_encoded,
+                source_mask,
+                target_embedded,
+                target_mask,
+                features_encoded,
+                features_mask,
+                causal_mask,
+            )
+        else:
+            decoded = self.module(
+                source_encoded,
+                source_mask,
+                target_embedded,
+                target_mask,
+                causal_mask,
+            )
+        return decoded, target_embedded
+
+    def get_module(self) -> nn.TransformerDecoder:
+        if self.has_features_encoder:
+            decoder_layer = (
+                transformer_layers.SeparateFeaturesTransformerDecoderLayer(
+                    d_model=self.decoder_input_size,
+                    dim_feedforward=self.hidden_size,
+                    nhead=self.attention_heads,
+                    dropout=self.dropout,
+                    activation="relu",
+                    norm_first=True,
+                    batch_first=True,
+                )
+            )
+            return transformer.SeparateFeaturesTransformerDecoder(
+                decoder_layer=decoder_layer,
+                num_layers=self.layers,
+                norm=nn.LayerNorm(self.embedding_size),
+            )
+        else:
+            decoder_layer = nn.TransformerDecoderLayer(
+                d_model=self.decoder_input_size,
+                dim_feedforward=self.hidden_size,
+                nhead=self.attention_heads,
+                dropout=self.dropout,
+                activation="relu",
+                norm_first=True,
+                batch_first=True,
+            )
+            return transformer.WrappedTransformerDecoder(
+                decoder_layer=decoder_layer,
+                num_layers=self.layers,
+                norm=nn.LayerNorm(self.embedding_size),
+            )
+
+    def _patch_attention(self, attention_module: torch.nn.Module) -> None:
+        """Wraps a module's forward pass such that `need_weights` is True.
+
+        Args:
+            attention_module (torch.nn.Module): the module from which we want
+                to track multiheaded attention weights.
+        """
+        forward_orig = attention_module.forward
+
+        def wrap(*args, **kwargs):
+            kwargs["need_weights"] = True
+            return forward_orig(*args, **kwargs)
+
+        attention_module.forward = wrap
+
+    @property
+    def name(self) -> str:
+        return f"pointer-generator {super().name}"
+
+
+# Rotary decoders.
+
+
+class RotaryPointerGeneratorTransformerDecoder(
+    transformer.RotaryTransformerModule, PointerGeneratorTransformerDecoder
+):
+    """Pointer-generator transformer decoder with rotary positional encodings.
+
+    Args:
+        *args: passed to superclass.
+        **kwargs: passed to superclass.
+    """
+
+    def get_module(self) -> nn.TransformerDecoder:
+        rope = position.RotaryPositionalEncoding(
+            embedding_size=self._rope_head_dim,
+            max_length=self._rope_max_length,
+        )
+        if self.has_features_encoder:
+            decoder_layer = transformer_layers.RotarySeparateFeaturesTransformerDecoderLayer(  # noqa: E501
+                rope,
+                d_model=self.decoder_input_size,
+                dim_feedforward=self.hidden_size,
+                nhead=self.attention_heads,
+                dropout=self.dropout,
+                activation="relu",
+                norm_first=True,
+                batch_first=True,
+            )
+            return transformer.SeparateFeaturesTransformerDecoder(
+                decoder_layer=decoder_layer,
+                num_layers=self.layers,
+                norm=nn.LayerNorm(self.embedding_size),
+            )
+        else:
+            decoder_layer = transformer_layers.RotaryTransformerDecoderLayer(
+                rope,
+                d_model=self.decoder_input_size,
+                dim_feedforward=self.hidden_size,
+                nhead=self.attention_heads,
+                dropout=self.dropout,
+                activation="relu",
+                norm_first=True,
+                batch_first=True,
+            )
+            return transformer.WrappedTransformerDecoder(
+                decoder_layer=decoder_layer,
+                num_layers=self.layers,
+                norm=nn.LayerNorm(self.embedding_size),
+            )
+
+    @property
+    def name(self) -> str:
+        return f"rotary {super().name}"

--- a/yoyodyne/models/modules/transformer.py
+++ b/yoyodyne/models/modules/transformer.py
@@ -389,7 +389,7 @@ class RotaryFeatureInvariantTransformerEncoder(
 
     @property
     def name(self) -> str:
-        return "rotary feature-invariant transformer"
+        return f"rotary {super().name}"
 
 
 # Decoder helpers.
@@ -551,140 +551,6 @@ class CausalTransformerDecoder(TransformerEncoder):
         return f"causal {super().name}"
 
 
-class PointerGeneratorTransformerDecoder(TransformerDecoder):
-    """A transformer decoder which tracks the output of multihead attention.
-
-    This is achieved with a hook into the forward pass.
-
-    After:
-        https://gist.github.com/airalcorn2/50ec06517ce96ecc143503e21fa6cb91
-
-    Args:
-        *args: passed to superclass.
-        has_features_encoder (bool, optional).
-        *kwargs: passed to superclass.
-    """
-
-    def __init__(
-        self,
-        *args,
-        has_features_encoder: bool = False,
-        **kwargs,
-    ):
-        self.has_features_encoder = has_features_encoder
-        super().__init__(*args, **kwargs)
-        # Stores the actual cross attentions.
-        self.attention_output = AttentionOutput()
-        # Refers to the attention from decoder to encoder.
-        self._patch_attention(self.module.layers[-1].multihead_attn)
-        self.hook_handle = self.module.layers[
-            -1
-        ].multihead_attn.register_forward_hook(self.attention_output)
-
-    def forward(
-        self,
-        source_encoded: torch.Tensor,
-        source_mask: torch.Tensor,
-        target: torch.Tensor,
-        target_mask: torch.Tensor | None,
-        embeddings: nn.Embedding,
-        *,
-        features_encoded: torch.Tensor | None = None,
-        features_mask: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Performs single pass of decoder module.
-
-        Args:
-            source_encoded (torch.Tensor).
-            source_mask (torch.Tensor).
-            target (torch.Tensor): current targets, which may be the full
-                target or previous decoded, of shape B x seq_len x hidden_size.
-            target_mask (torch.Tensor).
-            embeddings (nn.Embedding).
-            features_encoded (torch.Tensor, optional).
-            features_mask (torch.Tensor, optional).
-
-        Returns:
-            tuple[torch.Tensor, torch.Tensor]: decoder outputs and the
-                embedded targets.
-        """
-        target_embedded = self.embed(target, embeddings)
-        causal_mask = self._causal_mask(target_embedded.size(1))
-        # -> B x seq_len x d_model.
-        if self.has_features_encoder:
-            decoded = self.module(
-                source_encoded,
-                source_mask,
-                target_embedded,
-                target_mask,
-                features_encoded,
-                features_mask,
-                causal_mask,
-            )
-        else:
-            decoded = self.module(
-                source_encoded,
-                source_mask,
-                target_embedded,
-                target_mask,
-                causal_mask,
-            )
-        return decoded, target_embedded
-
-    def get_module(self) -> nn.TransformerDecoder:
-        if self.has_features_encoder:
-            decoder_layer = (
-                transformer_layers.SeparateFeaturesTransformerDecoderLayer(
-                    d_model=self.decoder_input_size,
-                    dim_feedforward=self.hidden_size,
-                    nhead=self.attention_heads,
-                    dropout=self.dropout,
-                    activation="relu",
-                    norm_first=True,
-                    batch_first=True,
-                )
-            )
-            return SeparateFeaturesTransformerDecoder(
-                decoder_layer=decoder_layer,
-                num_layers=self.layers,
-                norm=nn.LayerNorm(self.embedding_size),
-            )
-        else:
-            decoder_layer = nn.TransformerDecoderLayer(
-                d_model=self.decoder_input_size,
-                dim_feedforward=self.hidden_size,
-                nhead=self.attention_heads,
-                dropout=self.dropout,
-                activation="relu",
-                norm_first=True,
-                batch_first=True,
-            )
-            return WrappedTransformerDecoder(
-                decoder_layer=decoder_layer,
-                num_layers=self.layers,
-                norm=nn.LayerNorm(self.embedding_size),
-            )
-
-    def _patch_attention(self, attention_module: torch.nn.Module) -> None:
-        """Wraps a module's forward pass such that `need_weights` is True.
-
-        Args:
-            attention_module (torch.nn.Module): the module from which we want
-                to track multiheaded attention weights.
-        """
-        forward_orig = attention_module.forward
-
-        def wrap(*args, **kwargs):
-            kwargs["need_weights"] = True
-            return forward_orig(*args, **kwargs)
-
-        attention_module.forward = wrap
-
-    @property
-    def name(self) -> str:
-        return f"pointer-generator {super().name}"
-
-
 class SeparateFeaturesTransformerDecoder(nn.TransformerDecoder):
     """Transformer decoder with separate features.
 
@@ -770,7 +636,7 @@ class RotaryTransformerDecoder(RotaryTransformerModule, TransformerDecoder):
 
     @property
     def name(self) -> str:
-        return "rotary transformer"
+        return f"rotary {super().name}"
 
 
 class RotaryCausalTransformerDecoder(
@@ -807,57 +673,4 @@ class RotaryCausalTransformerDecoder(
 
     @property
     def name(self) -> str:
-        return "rotary causal transformer"
-
-
-class RotaryPointerGeneratorTransformerDecoder(
-    RotaryTransformerModule, PointerGeneratorTransformerDecoder
-):
-    """Pointer-generator transformer decoder with rotary positional encodings.
-
-    Args:
-        *args: passed to superclass.
-        **kwargs: passed to superclass.
-    """
-
-    def get_module(self) -> nn.TransformerDecoder:
-        rope = position.RotaryPositionalEncoding(
-            embedding_size=self._rope_head_dim,
-            max_length=self._rope_max_length,
-        )
-        if self.has_features_encoder:
-            decoder_layer = transformer_layers.RotarySeparateFeaturesTransformerDecoderLayer(  # noqa: E501
-                rope,
-                d_model=self.decoder_input_size,
-                dim_feedforward=self.hidden_size,
-                nhead=self.attention_heads,
-                dropout=self.dropout,
-                activation="relu",
-                norm_first=True,
-                batch_first=True,
-            )
-            return SeparateFeaturesTransformerDecoder(
-                decoder_layer=decoder_layer,
-                num_layers=self.layers,
-                norm=nn.LayerNorm(self.embedding_size),
-            )
-        else:
-            decoder_layer = transformer_layers.RotaryTransformerDecoderLayer(
-                rope,
-                d_model=self.decoder_input_size,
-                dim_feedforward=self.hidden_size,
-                nhead=self.attention_heads,
-                dropout=self.dropout,
-                activation="relu",
-                norm_first=True,
-                batch_first=True,
-            )
-            return WrappedTransformerDecoder(
-                decoder_layer=decoder_layer,
-                num_layers=self.layers,
-                norm=nn.LayerNorm(self.embedding_size),
-            )
-
-    @property
-    def name(self) -> str:
-        return "rotary pointer-generator transformer"
+        return f"rotary {super().name}"


### PR DESCRIPTION
There is no RNN pointer generator decoder module (the decoder logic is split across an ordinary RNN encoder and the model) but there is a separate one for transformers (and a rotary variant). We put this in a separate file to reduce the considerable length of the transformer module file by about 200 lines.

Some minor drivebys are applied; particularly some streamlining of the module unit test.